### PR TITLE
rest: handle err != rest.Error

### DIFF
--- a/rest/account_apikey.go
+++ b/rest/account_apikey.go
@@ -44,10 +44,14 @@ func (s *APIKeysService) Get(keyID string) (*account.APIKey, *http.Response, err
 	var a account.APIKey
 	resp, err := s.client.Do(req, &a)
 	if err != nil {
-		if err.(*Error).Message == "unknown api key" {
-			return nil, resp, ErrKeyMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "unknown api key" {
+				return nil, resp, ErrKeyMissing
+			}
+		default:
+			return nil, resp, err
 		}
-		return nil, resp, err
 	}
 
 	return &a, resp, nil
@@ -65,10 +69,14 @@ func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
 	// Update account fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &a)
 	if err != nil {
-		if err.(*Error).Message == fmt.Sprintf("api key with name \"%s\" exists", a.Name) {
-			return resp, ErrKeyExists
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == fmt.Sprintf("api key with name \"%s\" exists", a.Name) {
+				return resp, ErrKeyExists
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -88,10 +96,14 @@ func (s *APIKeysService) Update(a *account.APIKey) (*http.Response, error) {
 	// Update apikey fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &a)
 	if err != nil {
-		if err.(*Error).Message == "unknown api key" {
-			return resp, ErrKeyMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "unknown api key" {
+				return resp, ErrKeyMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -110,10 +122,14 @@ func (s *APIKeysService) Delete(keyID string) (*http.Response, error) {
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		if err.(*Error).Message == "unknown api key" {
-			return resp, ErrKeyMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "unknown api key" {
+				return resp, ErrKeyMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil

--- a/rest/account_team.go
+++ b/rest/account_team.go
@@ -43,10 +43,14 @@ func (s *TeamsService) Get(id string) (*account.Team, *http.Response, error) {
 	var t account.Team
 	resp, err := s.client.Do(req, &t)
 	if err != nil {
-		if err.(*Error).Message == "Unknown team id" {
-			return nil, resp, ErrTeamMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "Unknown team id" {
+				return nil, resp, ErrTeamMissing
+			}
+		default:
+			return nil, resp, err
 		}
-		return nil, resp, err
 	}
 
 	return &t, resp, nil
@@ -64,10 +68,14 @@ func (s *TeamsService) Create(t *account.Team) (*http.Response, error) {
 	// Update team fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &t)
 	if err != nil {
-		if err.(*Error).Message == fmt.Sprintf("team with name \"%s\" exists", t.Name) {
-			return resp, ErrTeamExists
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == fmt.Sprintf("team with name \"%s\" exists", t.Name) {
+				return resp, ErrTeamExists
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -87,10 +95,14 @@ func (s *TeamsService) Update(t *account.Team) (*http.Response, error) {
 	// Update team fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &t)
 	if err != nil {
-		if err.(*Error).Message == "unknown team id" {
-			return resp, ErrTeamMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "unknown team id" {
+				return resp, ErrTeamMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -109,10 +121,14 @@ func (s *TeamsService) Delete(id string) (*http.Response, error) {
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		if err.(*Error).Message == "unknown team id" {
-			return resp, ErrTeamMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "unknown team id" {
+				return resp, ErrTeamMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil

--- a/rest/account_user.go
+++ b/rest/account_user.go
@@ -43,10 +43,14 @@ func (s *UsersService) Get(username string) (*account.User, *http.Response, erro
 	var u account.User
 	resp, err := s.client.Do(req, &u)
 	if err != nil {
-		if err.(*Error).Message == "Unknown user" {
-			return nil, resp, ErrUserMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "Unknown user" {
+				return nil, resp, ErrUserMissing
+			}
+		default:
+			return nil, resp, err
 		}
-		return nil, resp, err
 	}
 
 	return &u, resp, nil
@@ -64,10 +68,14 @@ func (s *UsersService) Create(u *account.User) (*http.Response, error) {
 	// Update user fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &u)
 	if err != nil {
-		if err.(*Error).Message == "request failed:Login Name is already in use." {
-			return resp, ErrUserExists
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "request failed:Login Name is already in use." {
+				return resp, ErrUserExists
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -87,10 +95,14 @@ func (s *UsersService) Update(u *account.User) (*http.Response, error) {
 	// Update user fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &u)
 	if err != nil {
-		if err.(*Error).Message == "Unknown user" {
-			return resp, ErrUserMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "Unknown user" {
+				return resp, ErrUserMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -109,10 +121,14 @@ func (s *UsersService) Delete(username string) (*http.Response, error) {
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		if err.(*Error).Message == "Unknown user" {
-			return resp, ErrUserMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "Unknown user" {
+				return resp, ErrUserMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil

--- a/rest/monitor_notify.go
+++ b/rest/monitor_notify.go
@@ -43,10 +43,14 @@ func (s *NotificationsService) Get(listID string) (*monitor.NotifyList, *http.Re
 	var nl monitor.NotifyList
 	resp, err := s.client.Do(req, &nl)
 	if err != nil {
-		if err.(*Error).Message == "unknown notification list" {
-			return nil, resp, ErrListMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "unknown notification list" {
+				return nil, resp, ErrListMissing
+			}
+		default:
+			return nil, resp, err
 		}
-		return nil, resp, err
 	}
 
 	return &nl, resp, nil
@@ -64,10 +68,14 @@ func (s *NotificationsService) Create(nl *monitor.NotifyList) (*http.Response, e
 	// Update notify list fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &nl)
 	if err != nil {
-		if err.(*Error).Message == fmt.Sprintf("notification list with name \"%s\" exists", nl.Name) {
-			return resp, ErrListExists
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == fmt.Sprintf("notification list with name \"%s\" exists", nl.Name) {
+				return resp, ErrListExists
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil

--- a/rest/record.go
+++ b/rest/record.go
@@ -25,10 +25,14 @@ func (s *RecordsService) Get(zone string, domain string, t string) (*dns.Record,
 	var r dns.Record
 	resp, err := s.client.Do(req, &r)
 	if err != nil {
-		if err.(*Error).Message == "record not found" {
-			return nil, resp, ErrRecordMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "record not found" {
+				return nil, resp, ErrRecordMissing
+			}
+		default:
+			return nil, resp, err
 		}
-		return nil, resp, err
 	}
 
 	return &r, resp, nil
@@ -49,11 +53,14 @@ func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
 	// Update record fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &r)
 	if err != nil {
-		switch err.(*Error).Message {
-		case "zone not found":
-			return resp, ErrZoneMissing
-		case "record already exists":
-			return resp, ErrRecordExists
+		switch err.(type) {
+		case *Error:
+			switch err.(*Error).Message {
+			case "zone not found":
+				return resp, ErrZoneMissing
+			case "record already exists":
+				return resp, ErrRecordExists
+			}
 		default:
 			return resp, err
 		}
@@ -77,11 +84,14 @@ func (s *RecordsService) Update(r *dns.Record) (*http.Response, error) {
 	// Update records fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &r)
 	if err != nil {
-		switch err.(*Error).Message {
-		case "zone not found":
-			return resp, ErrZoneMissing
-		case "record already exists":
-			return resp, ErrRecordExists
+		switch err.(type) {
+		case *Error:
+			switch err.(*Error).Message {
+			case "zone not found":
+				return resp, ErrZoneMissing
+			case "record already exists":
+				return resp, ErrRecordExists
+			}
 		default:
 			return resp, err
 		}
@@ -103,10 +113,14 @@ func (s *RecordsService) Delete(zone string, domain string, t string) (*http.Res
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		if err.(*Error).Message == "record not found" {
-			return resp, ErrRecordMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "record not found" {
+				return resp, ErrRecordMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil

--- a/rest/zone.go
+++ b/rest/zone.go
@@ -43,10 +43,14 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 	var z dns.Zone
 	resp, err := s.client.Do(req, &z)
 	if err != nil {
-		if err.(*Error).Message == "zone not found" {
-			return nil, resp, ErrZoneMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "zone not found" {
+				return nil, resp, ErrZoneMissing
+			}
+		default:
+			return nil, resp, err
 		}
-		return nil, resp, err
 	}
 
 	return &z, resp, nil
@@ -66,10 +70,14 @@ func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
 	// Update zones fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &z)
 	if err != nil {
-		if err.(*Error).Message == "zone already exists" {
-			return resp, ErrZoneExists
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "zone already exists" {
+				return resp, ErrZoneExists
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -89,10 +97,14 @@ func (s *ZonesService) Update(z *dns.Zone) (*http.Response, error) {
 	// Update zones fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &z)
 	if err != nil {
-		if err.(*Error).Message == "zone not found" {
-			return resp, ErrZoneMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "zone not found" {
+				return resp, ErrZoneMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil
@@ -111,10 +123,14 @@ func (s *ZonesService) Delete(zone string) (*http.Response, error) {
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
-		if err.(*Error).Message == "zone not found" {
-			return resp, ErrZoneMissing
+		switch err.(type) {
+		case *Error:
+			if err.(*Error).Message == "zone not found" {
+				return resp, ErrZoneMissing
+			}
+		default:
+			return resp, err
 		}
-		return resp, err
 	}
 
 	return resp, nil


### PR DESCRIPTION
It's possible for the REST requests to fail for json.SyntaxError, so
response handling can't safely cast to rest.Error in all cases.

Updated all error handling which assumed rest.Error in:
- APIKeysService
- NotificationsService
- RecordsService
- TeamsService
- UsersService
- ZonesService

Fixes #22
