### PR TITLE
Url of api docs moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NS1 Golang SDK
 
-The golang client for the NS1 API: https://api.nsone.net/
+The golang client for the NS1 API: https://ns1.com/api/
 
 # Installing
 


### PR DESCRIPTION
Im not sure why there isn't a redirect here but in the meantime lets update this.