### PR TITLE
Fixing fallthrough behaviour for error handlers

### DIFF
--- a/rest/account_apikey.go
+++ b/rest/account_apikey.go
@@ -49,9 +49,9 @@ func (s *APIKeysService) Get(keyID string) (*account.APIKey, *http.Response, err
 			if err.(*Error).Message == "unknown api key" {
 				return nil, resp, ErrKeyMissing
 			}
-		default:
-			return nil, resp, err
+
 		}
+		return nil, resp, err
 	}
 
 	return &a, resp, nil
@@ -74,9 +74,8 @@ func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
 			if err.(*Error).Message == fmt.Sprintf("api key with name \"%s\" exists", a.Name) {
 				return resp, ErrKeyExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -101,9 +100,8 @@ func (s *APIKeysService) Update(a *account.APIKey) (*http.Response, error) {
 			if err.(*Error).Message == "unknown api key" {
 				return resp, ErrKeyMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -127,9 +125,8 @@ func (s *APIKeysService) Delete(keyID string) (*http.Response, error) {
 			if err.(*Error).Message == "unknown api key" {
 				return resp, ErrKeyMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/rest/account_team.go
+++ b/rest/account_team.go
@@ -48,9 +48,8 @@ func (s *TeamsService) Get(id string) (*account.Team, *http.Response, error) {
 			if err.(*Error).Message == "Unknown team id" {
 				return nil, resp, ErrTeamMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &t, resp, nil
@@ -73,9 +72,8 @@ func (s *TeamsService) Create(t *account.Team) (*http.Response, error) {
 			if err.(*Error).Message == fmt.Sprintf("team with name \"%s\" exists", t.Name) {
 				return resp, ErrTeamExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -100,9 +98,8 @@ func (s *TeamsService) Update(t *account.Team) (*http.Response, error) {
 			if err.(*Error).Message == "unknown team id" {
 				return resp, ErrTeamMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -126,9 +123,8 @@ func (s *TeamsService) Delete(id string) (*http.Response, error) {
 			if err.(*Error).Message == "unknown team id" {
 				return resp, ErrTeamMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/rest/account_user.go
+++ b/rest/account_user.go
@@ -48,9 +48,8 @@ func (s *UsersService) Get(username string) (*account.User, *http.Response, erro
 			if err.(*Error).Message == "Unknown user" {
 				return nil, resp, ErrUserMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &u, resp, nil
@@ -73,9 +72,8 @@ func (s *UsersService) Create(u *account.User) (*http.Response, error) {
 			if err.(*Error).Message == "request failed:Login Name is already in use." {
 				return resp, ErrUserExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -100,9 +98,8 @@ func (s *UsersService) Update(u *account.User) (*http.Response, error) {
 			if err.(*Error).Message == "Unknown user" {
 				return resp, ErrUserMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -126,9 +123,8 @@ func (s *UsersService) Delete(username string) (*http.Response, error) {
 			if err.(*Error).Message == "Unknown user" {
 				return resp, ErrUserMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/rest/monitor_notify.go
+++ b/rest/monitor_notify.go
@@ -48,9 +48,8 @@ func (s *NotificationsService) Get(listID string) (*monitor.NotifyList, *http.Re
 			if err.(*Error).Message == "unknown notification list" {
 				return nil, resp, ErrListMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &nl, resp, nil
@@ -73,9 +72,8 @@ func (s *NotificationsService) Create(nl *monitor.NotifyList) (*http.Response, e
 			if err.(*Error).Message == fmt.Sprintf("notification list with name \"%s\" exists", nl.Name) {
 				return resp, ErrListExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/rest/record.go
+++ b/rest/record.go
@@ -30,9 +30,8 @@ func (s *RecordsService) Get(zone, domain, t string) (*dns.Record, *http.Respons
 			if err.(*Error).Message == "record not found" {
 				return nil, resp, ErrRecordMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &r, resp, nil
@@ -61,9 +60,8 @@ func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
 			case "record already exists":
 				return resp, ErrRecordExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -92,9 +90,8 @@ func (s *RecordsService) Update(r *dns.Record) (*http.Response, error) {
 			case "record already exists":
 				return resp, ErrRecordExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -118,9 +115,8 @@ func (s *RecordsService) Delete(zone string, domain string, t string) (*http.Res
 			if err.(*Error).Message == "record not found" {
 				return resp, ErrRecordMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/rest/zone.go
+++ b/rest/zone.go
@@ -48,9 +48,8 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 			if err.(*Error).Message == "zone not found" {
 				return nil, resp, ErrZoneMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &z, resp, nil
@@ -75,9 +74,8 @@ func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
 			if err.(*Error).Message == "zone already exists" {
 				return resp, ErrZoneExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -102,9 +100,8 @@ func (s *ZonesService) Update(z *dns.Zone) (*http.Response, error) {
 			if err.(*Error).Message == "zone not found" {
 				return resp, ErrZoneMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -128,9 +125,8 @@ func (s *ZonesService) Delete(zone string) (*http.Response, error) {
 			if err.(*Error).Message == "zone not found" {
 				return resp, ErrZoneMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil


### PR DESCRIPTION
This fixes #33 for me, where non-matched error messages would result in a nil error being returned. Could likely remove the type switch altogether or replace all of these with a central message->error type lookup managed by client.Do. But this solves my immediate problem.