### PR TITLE
Convert ZoneRecord Tier field to float

### DIFF
--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -48,7 +48,7 @@ type ZoneRecord struct {
 	ID       string   `json:"id,omitempty"`
 	Link     string   `json:"link,omitempty"`
 	ShortAns []string `json:"short_answers,omitempty"`
-	Tier     int      `json:"tier,omitempty"`
+	Tier     float64  `json:"tier,omitempty"`
 	TTL      int      `json:"ttl,omitempty"`
 	Type     string   `json:"type,omitempty"`
 }

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -1,5 +1,6 @@
 package dns
 
+import "encoding/json"
 import "gopkg.in/ns1/ns1-go.v2/rest/model/data"
 
 // Zone wraps an NS1 /zone resource
@@ -44,13 +45,13 @@ func (z Zone) String() string {
 
 // ZoneRecord wraps Zone's "records" attribute
 type ZoneRecord struct {
-	Domain   string   `json:"Domain,omitempty"`
-	ID       string   `json:"id,omitempty"`
-	Link     string   `json:"link,omitempty"`
-	ShortAns []string `json:"short_answers,omitempty"`
-	Tier     float64  `json:"tier,omitempty"`
-	TTL      int      `json:"ttl,omitempty"`
-	Type     string   `json:"type,omitempty"`
+	Domain   string      `json:"Domain,omitempty"`
+	ID       string      `json:"id,omitempty"`
+	Link     string      `json:"link,omitempty"`
+	ShortAns []string    `json:"short_answers,omitempty"`
+	Tier     json.Number `json:"tier,omitempty"`
+	TTL      int         `json:"ttl,omitempty"`
+	Type     string      `json:"type,omitempty"`
 }
 
 // ZonePrimary wraps a Zone's "primary" attribute

--- a/rest/model/dns/zone_test.go
+++ b/rest/model/dns/zone_test.go
@@ -9,6 +9,44 @@ import (
 	"gopkg.in/ns1/ns1-go.v2/rest/model/data"
 )
 
+func TestUnmarshalZoneRecords(t *testing.T) {
+  d := []byte(`[
+    {
+      "domain": "foo.test.zone",
+      "short_answers": [
+        "1.2.3.4"
+      ],
+      "link": null,
+      "ttl": 180,
+      "tier": 1.0,
+      "type": "A",
+      "id": "835d91f01c56932156905bf7"
+    },
+    {
+      "domain": "bar.test.zone",
+      "short_answers": [
+        "5.6.7.8"
+      ],
+      "link": null,
+      "ttl": 180,
+      "tier": 1,
+      "type": "A",
+      "id": "367d91f01c56932156905v98"
+    }
+]
+`)
+  zrl := []*ZoneRecord{}
+  if err := json.Unmarshal(d, &zrl); err != nil {
+    t.Error(err)
+  }
+
+  if len(zrl) != 2 {
+    fmt.Println(zrl)
+    t.Error("Do not have 2 records in list")
+  }
+
+}
+
 func TestUnmarshalZones(t *testing.T) {
 	d := []byte(`[
    {  


### PR DESCRIPTION
Caught this when using the terraform-provider-ns1 for which some zone records returned from the API would have the field `Tier` set to `1.0`

```json: cannot unmarshal number 1.0 into Go struct field ZoneRecord.tier of type int```

This was also reported in hashicorp/terraform#16761

Checking the API response from `https://api.nsone.net/v1/zones/:zone` it returns mixed records with the field `Tier` either as an int or float. This seems to only appear on recently modified records, ~1month.

Testing done:

`go test`