### PR TITLE
Make meta terraform friendly

### DIFF
--- a/rest/model/data/meta.go
+++ b/rest/model/data/meta.go
@@ -162,9 +162,8 @@ func FormatInterface(i interface{}) string {
 	case bool:
 		if v {
 			return "1"
-		} else {
-			return "0"
 		}
+		return "0"
 	case int:
 		return strconv.FormatInt(int64(v), 10)
 	case float64:

--- a/rest/model/data/meta.go
+++ b/rest/model/data/meta.go
@@ -160,11 +160,18 @@ func FormatInterface(i interface{}) string {
 	case string:
 		return v
 	case bool:
-		return strconv.FormatBool(v)
+		if v {
+			return "1"
+		} else {
+			return "0"
+		}
 	case int:
 		return strconv.FormatInt(int64(v), 10)
 	case float64:
-		return strconv.FormatFloat(v, 'f', 2, 64)
+		if isIntegral(v) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
 	case []string:
 		return strings.Join(v, ",")
 	case FeedPtr:
@@ -191,11 +198,6 @@ func ParseType(s string) interface{} {
 	err := json.Unmarshal([]byte(s), &feedptr)
 	if err == nil {
 		return feedptr
-	}
-
-	b, err := strconv.ParseBool(s)
-	if err == nil {
-		return b
 	}
 
 	f, err := strconv.ParseFloat(s, 64)
@@ -225,7 +227,15 @@ func MetaFromMap(m map[string]interface{}) *Meta {
 		name := ToCamel(k)
 		if _, ok := mt.FieldByName(name); ok {
 			fv := mv.FieldByName(name)
-			fv.Set(reflect.ValueOf(ParseType(v.(string))))
+			if name == "Up" {
+				if v.(string) == "1" {
+					fv.Set(reflect.ValueOf(true))
+				} else {
+					fv.Set(reflect.ValueOf(false))
+				}
+			} else {
+				fv.Set(reflect.ValueOf(ParseType(v.(string))))
+			}
 		}
 	}
 	return meta

--- a/rest/model/data/meta_test.go
+++ b/rest/model/data/meta_test.go
@@ -11,12 +11,12 @@ func TestMeta_StringMap(t *testing.T) {
 
 	m := meta.StringMap()
 
-	if m["up"].(string) != "true" {
-		t.Fatal("up should be true")
+	if m["up"].(string) != "1" {
+		t.Fatal("up should be 1")
 	}
 
-	if m["latitude"].(string) != "0.50" {
-		t.Fatal("latitude should be '0.50'")
+	if m["latitude"].(string) != "0.5" {
+		t.Fatal("latitude should be '0.5'")
 	}
 
 	expected := `{"feed":"12345678"}`
@@ -63,7 +63,7 @@ func TestMetaFromMap(t *testing.T) {
 	m := make(map[string]interface{})
 
 	m["latitude"] = "0.50"
-	m["up"] = "true"
+	m["up"] = "1"
 	m["connections"] = "5"
 	m["longitude"] = `{"feed":"12345678"}`
 	meta := MetaFromMap(m)


### PR DESCRIPTION
I don't love this, but we need to make what we get from the api match terraform's internal state representation of these values.

boolean => 1 or 0
floats => shortest possible decimal format
