### PR TITLE
removing omitempty by customer request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.6.2
+- 1.10.3
 go_import_path: gopkg.in/ns1/ns1-go.v2
 script: script/test
 notifications:

--- a/rest/model/dns/example_test.go
+++ b/rest/model/dns/example_test.go
@@ -18,7 +18,7 @@ func ExampleZone() {
 }
 
 // Example references https://ns1.com/articles/primary-dns-with-ns1
-func ExamplePrimaryZone() {
+func ExampleZone_MakePrimary() {
 	// Secondary/slave dns server info.
 	secondary := dns.ZoneSecondaryServer{
 		IP:     "1.2.3.4",
@@ -123,7 +123,7 @@ func ExampleRecord() {
 	// false
 }
 
-func ExampleRecordLink() {
+func ExampleRecord_LinkTo() {
 	// Construct the src record
 	srcRecord := dns.NewRecord("test.com", "a", "A")
 	srcRecord.TTL = 300

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -23,7 +23,7 @@ type Record struct {
 	// Answers must all be of the same type as the record.
 	Answers []*Answer `json:"answers"`
 	// The records' filter chain.
-	Filters []*filter.Filter `json:"filters,omitempty"`
+	Filters []*filter.Filter `json:"filters"`
 	// The records' regions.
 	Regions data.Regions `json:"regions,omitempty"`
 }


### PR DESCRIPTION
By customer request, we're removing omitempty so that customers can remove filters applied to a record by sending either [] or null - @jamorency 

Implications are that if customers want to update a record, they must always send the full set of filters, or they will not be applied. We've spoken about other possible breaking changes and have decided that this is still worth pursuing.