### PR TITLE
fix issue creating new ns1 record

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -44,6 +44,7 @@ func NewRecord(zone string, domain string, t string) *Record {
 		Domain:  domain,
 		Type:    t,
 		Answers: []*Answer{},
+		Filters: []*filter.Filter{},
 		Regions: data.Regions{},
 	}
 }


### PR DESCRIPTION
after PR #49 was merged, there was an issue creating new records. this should fix it.

The exact error I was seeing, via Terraform (using the latest ns1 terraform provider at `master`):

```
1 error(s) occurred:

* ns1_record.rec3: 1 error(s) occurred:

* ns1_record.rec3: PUT https://api.nsone.net/v1/zones/serverless.farm/test3.serverless.farm/A: 400 Input validation failed (Value None for field '<obj>.filters' is not of type array)
```