### PR TITLE
Fix bug when "up" is a "feed" in Terraform

### DIFF
--- a/rest/model/data/meta.go
+++ b/rest/model/data/meta.go
@@ -179,6 +179,9 @@ func FormatInterface(i interface{}) string {
 			slc = append(slc, s.(string))
 		}
 		return strings.Join(slc, ",")
+	case map[string]interface{}:
+		data, _ := json.Marshal(v)
+		return string(data)
 	case FeedPtr:
 		data, _ := json.Marshal(v)
 		return string(data)
@@ -242,8 +245,10 @@ func MetaFromMap(m map[string]interface{}) *Meta {
 			if name == "Up" {
 				if v.(string) == "1" {
 					fv.Set(reflect.ValueOf(true))
-				} else {
+				} else if v.(string) == "0" {
 					fv.Set(reflect.ValueOf(false))
+				} else {
+					fv.Set(reflect.ValueOf(ParseType(v.(string))))
 				}
 			} else {
 				fv.Set(reflect.ValueOf(ParseType(v.(string))))


### PR DESCRIPTION
If an answer's `meta` field's `up` value is not a bool but a feed, it causes a panic and crashes terraform.

related to this issue:
https://github.com/terraform-providers/terraform-provider-ns1/issues/31

Add new case where interface could be a `map[string]interface{}`.

Also, allow the `up` value to be something other than a bool, since it can be a feed.

Example Terraform:
```hcl
resource "ns1_record" "blerb" {
  domain = "blerb.serverless.farm"
  zone   = "serverless.farm"
  type   = "A"
  ttl    = 300

  answers = {
    answer = "10.20.20.10"
    meta = {
      up = "${jsonencode(map("feed", "5b7c8c10a632f600017a90fa"))}"
    }
  }
}
```

Since the value of `up` has to be a string, i'm using TF's `jsonencode()` and `map()` functions to generate json like `{"feed":"5b7c8c10a632f600017a90fa"}`. The current behavior with this terraform code is that it'll `apply` successfully but a subsequent `plan` will show:
```
  ~ ns1_record.blerb
      answers.0.meta.up: "0" => "{\"feed\":\"5b7c8c10a632f600017a90fa\"}"
```

With this fix, a subsequent `plan` will show "No changes."