### PR TITLE
downcase headers to comply with rfc2616

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -259,13 +260,13 @@ func (c *Client) RateLimitStrategySleep() {
 func parseRate(resp *http.Response) RateLimit {
 	var rl RateLimit
 
-	if limit := resp.Header.Get(headerRateLimit); limit != "" {
+	if limit := resp.Header.Get(strings.ToLower(headerRateLimit)); limit != "" {
 		rl.Limit, _ = strconv.Atoi(limit)
 	}
-	if remaining := resp.Header.Get(headerRateRemaining); remaining != "" {
+	if remaining := resp.Header.Get(strings.ToLower(headerRateRemaining)); remaining != "" {
 		rl.Remaining, _ = strconv.Atoi(remaining)
 	}
-	if period := resp.Header.Get(headerRatePeriod); period != "" {
+	if period := resp.Header.Get(strings.ToLower(headerRatePeriod)); period != "" {
 		rl.Period, _ = strconv.Atoi(period)
 	}
 


### PR DESCRIPTION
Per [rfc2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html), header field names are to be case-insensitive.