### PR TITLE
record.Update: catch record not found

### DIFF
--- a/rest/record.go
+++ b/rest/record.go
@@ -57,6 +57,8 @@ func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
 			switch err.(*Error).Message {
 			case "zone not found":
 				return resp, ErrZoneMissing
+			case "record not found":
+				return resp, ErrRecordMissing
 			case "record already exists":
 				return resp, ErrRecordExists
 			}


### PR DESCRIPTION
This makes it consistent with other places where we catch errors.