### PR TITLE
catch record not found in update

### DIFF
--- a/rest/record.go
+++ b/rest/record.go
@@ -57,8 +57,6 @@ func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
 			switch err.(*Error).Message {
 			case "zone not found":
 				return resp, ErrZoneMissing
-			case "record not found":
-				return resp, ErrRecordMissing
 			case "record already exists":
 				return resp, ErrRecordExists
 			}
@@ -89,6 +87,8 @@ func (s *RecordsService) Update(r *dns.Record) (*http.Response, error) {
 			switch err.(*Error).Message {
 			case "zone not found":
 				return resp, ErrZoneMissing
+			case "record not found":
+				return resp, ErrRecordMissing
 			case "record already exists":
 				return resp, ErrRecordExists
 			}


### PR DESCRIPTION
The previous PR was actually in the wrong spot (in the create spot) where it wouldn't have happened.

