### PR TITLE
Fix sending empty TSIG struct when creating secondary zone

### DIFF
--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -84,7 +84,7 @@ type ZoneSecondary struct {
 	PrimaryPort int    `json:"primary_port,omitempty"`
 	Enabled     bool   `json:"enabled"`
 
-	TSIG *TSIG `json:"tsig"`
+	TSIG *TSIG `json:"tsig,omitempty"`
 }
 
 // TSIG is a zones transaction signature.


### PR DESCRIPTION
Creating a secondary zone by configuring a zone using the `MakeSecondary()` method of the zone model currently fails on Create() with the following error:
```
400 Input validation failed (Value None for field '<obj>.secondary.tsig' is not of type object)
```
This is because the TSIG field of the ZoneSecondary struct is included in the PUT request, even if it is empty.  This hotfix resolves this issue by adding `omitempty` to the TSIG field.