### PR TITLE
Hotfix/allow feed ptr meta var

### DIFF
--- a/rest/model/data/meta.go
+++ b/rest/model/data/meta.go
@@ -247,9 +247,9 @@ func MetaFromMap(m map[string]interface{}) *Meta {
 		if _, ok := mt.FieldByName(name); ok {
 			fv := mv.FieldByName(name)
 			if name == "Up" {
-				if v.(string) == "1" {
+				if v.(string) == "1" || strings.ToLower(v.(string)) == "true" {
 					fv.Set(reflect.ValueOf(true))
-				} else if v.(string) == "0" {
+				} else if v.(string) == "0" || strings.ToLower(v.(string)) == "false" {
 					fv.Set(reflect.ValueOf(false))
 				} else {
 					fv.Set(reflect.ValueOf(ParseType(v.(string))))

--- a/rest/model/data/meta.go
+++ b/rest/model/data/meta.go
@@ -182,10 +182,12 @@ func FormatInterface(i interface{}) string {
 	case map[string]interface{}:
 		// Required for Terraform workaround to allow users to submit raw json of feed pointer
 		// as value for metadata.  See https://github.com/terraform-providers/terraform-provider-ns1/issues/35
-		mapVal := i.(map[string]interface{})
-		feedPtr := FeedPtr{FeedID: mapVal["feed"].(string)}
-		data, _ := json.Marshal(feedPtr)
-		return string(data)
+		if val, ok := v["feed"].(string); ok {
+			feedPtr := FeedPtr{FeedID: val}
+			data, _ := json.Marshal(feedPtr)
+			return string(data)
+		}
+		panic(fmt.Sprintf("expected map to contain 'feed' key to marshal as feedPtr, got: %+v", v))
 	case FeedPtr:
 		data, _ := json.Marshal(v)
 		return string(data)


### PR DESCRIPTION
Allows raw json for a feed pointer to be used as a value for a metadata key, which in turn enables a feed pointer to be generated when the caller generating the input does not have the ability to create new FeedPtr objects.

This is required to resolve https://github.com/terraform-providers/terraform-provider-ns1/issues/35 and enable a workaround to use feed pointers as metadata values via Terraform.

This PR also disables default behavior of casting all values for the `up` metadata key that != 1 as `false`.  This enables using a feed pointer as a value for `up` and also prepares for Terraform 0.12, in which string conversions of boolean configuration values will no longer be automatically converted to `1` or `0` (See https://github.com/hashicorp/terraform/issues/19618 for more info).

This PR is based on a fork by @glennslaven, a big thanks is owed for his contribution!