### PR TITLE
INT-49: Add another rate limit strategy

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -259,6 +259,17 @@ func (c *Client) RateLimitStrategySleep() {
 	}
 }
 
+// RateLimitStrategyConcurrent sleeps for WaitTime * parallelism when
+// remaining is less than or equal to parallelism.
+func (c *Client) RateLimitStrategyConcurrent(parallelism int) {
+	c.RateLimitFunc = func(rl RateLimit) {
+		if rl.Remaining <= parallelism {
+			wait := rl.WaitTime() * time.Duration(parallelism)
+			time.Sleep(wait)
+		}
+	}
+}
+
 // parseRate parses rate related headers from http response.
 func parseRate(resp *http.Response) RateLimit {
 	var rl RateLimit


### PR DESCRIPTION
RateLimitStrategyConcurrent might help in some use cases. It takes a
parallelism arg, and when remaining tokens are less than or equal to
that number, sleeps for WaitTime * parallelism.