### PR TITLE
CAA support

### DIFF
--- a/rest/_examples/zones.go
+++ b/rest/_examples/zones.go
@@ -142,6 +142,23 @@ func main() {
 		}
 	}
 
+	caaRec := dns.NewRecord(domain, "", "CAA")
+
+	caaRec.Answers = []*dns.Answer{
+		dns.NewCAAAnswer(0, "issue", "digicert.com"),
+		dns.NewCAAAnswer(0, "issue", "sectigo.com"),
+		dns.NewCAAAnswer(0, "iodef", "sectigo.com"),
+	}
+	_, err = client.Records.Create(caaRec)
+	if err != nil {
+		// Ignore if record already exists
+		if err != api.ErrRecordExists {
+			log.Fatal(err)
+		} else {
+			log.Printf("Create %s: %s \n", caaRec, err)
+		}
+	}
+
 	// Add a AAAA, specify ttl of 300 seconds
 	aaaaRec := dns.NewRecord(domain, "honey6", "AAAA")
 	aaaaRec.TTL = 300

--- a/rest/model/dns/answer.go
+++ b/rest/model/dns/answer.go
@@ -89,10 +89,11 @@ func NewMXAnswer(pri int, host string) *Answer {
 	}
 }
 
-func NewCAAAnswer(pri int, issuance string, ca string) *Answer {
+// NewCAAAnswer creates an Answer for a CAA record as per https://tools.ietf.org/html/rfc6844
+func NewCAAAnswer(flag int, tag string, value string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []interface{}{strconv.Itoa(pri), issuance, ca},
+		Rdata: []interface{}{strconv.Itoa(flag), tag, value},
 	}
 }
 

--- a/rest/model/dns/answer.go
+++ b/rest/model/dns/answer.go
@@ -18,7 +18,7 @@ type Answer struct {
 	// Av4: ["1.1.1.1"]
 	// Av6: ["2001:db8:85a3::8a2e:370:7334"]
 	// MX:  [10, "2.2.2.2"]
-	Rdata []string `json:"answer"`
+	Rdata []interface{} `json:"answer"`
 
 	// Region(grouping) that answer belongs to.
 	RegionName string `json:"region,omitempty"`
@@ -34,7 +34,7 @@ func (a *Answer) SetRegion(name string) {
 }
 
 // NewAnswer creates a generic Answer with given rdata.
-func NewAnswer(rdata []string) *Answer {
+func NewAnswer(rdata []interface{}) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
 		Rdata: rdata,
@@ -45,7 +45,7 @@ func NewAnswer(rdata []string) *Answer {
 func NewAv4Answer(host string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []string{host},
+		Rdata: []interface{}{host},
 	}
 }
 
@@ -53,7 +53,7 @@ func NewAv4Answer(host string) *Answer {
 func NewAv6Answer(host string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []string{host},
+		Rdata: []interface{}{host},
 	}
 }
 
@@ -61,7 +61,7 @@ func NewAv6Answer(host string) *Answer {
 func NewALIASAnswer(host string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []string{host},
+		Rdata: []interface{}{host},
 	}
 }
 
@@ -69,7 +69,7 @@ func NewALIASAnswer(host string) *Answer {
 func NewCNAMEAnswer(name string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []string{name},
+		Rdata: []interface{}{name},
 	}
 }
 
@@ -77,7 +77,7 @@ func NewCNAMEAnswer(name string) *Answer {
 func NewTXTAnswer(text string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []string{text},
+		Rdata: []interface{}{text},
 	}
 }
 
@@ -85,14 +85,14 @@ func NewTXTAnswer(text string) *Answer {
 func NewMXAnswer(pri int, host string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []string{strconv.Itoa(pri), host},
+		Rdata: []interface{}{strconv.Itoa(pri), host},
 	}
 }
 
-func NewCAAAnswer(pri int, host string, caa string) *Answer {
+func NewCAAAnswer(pri int, issuance string, ca string) *Answer {
 	return &Answer{
 		Meta:  &data.Meta{},
-		Rdata: []string{strconv.Itoa(pri), host, caa},
+		Rdata: []interface{}{strconv.Itoa(pri), issuance, ca},
 	}
 }
 
@@ -100,7 +100,7 @@ func NewCAAAnswer(pri int, host string, caa string) *Answer {
 func NewSRVAnswer(priority, weight, port int, target string) *Answer {
 	return &Answer{
 		Meta: &data.Meta{},
-		Rdata: []string{
+		Rdata: []interface{}{
 			strconv.Itoa(priority),
 			strconv.Itoa(weight),
 			strconv.Itoa(port),

--- a/rest/model/dns/answer.go
+++ b/rest/model/dns/answer.go
@@ -89,6 +89,13 @@ func NewMXAnswer(pri int, host string) *Answer {
 	}
 }
 
+func NewCAAAnswer(pri int, host string, caa string) *Answer {
+	return &Answer{
+		Meta:  &data.Meta{},
+		Rdata: []string{strconv.Itoa(pri), host, caa},
+	}
+}
+
 // NewSRVAnswer creates an Answer for SRV record.
 func NewSRVAnswer(priority, weight, port int, target string) *Answer {
 	return &Answer{

--- a/rest/record_test.go
+++ b/rest/record_test.go
@@ -1,0 +1,45 @@
+package rest
+
+import (
+	"fmt"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+)
+
+func TestCaaRecordIntegrationTest(t *testing.T){
+	apiKey := os.Getenv("NS1_APIKEY")
+	testDomain := os.Getenv("NS1_TESTDOMAIN")
+
+	httpClient := &http.Client{Timeout: time.Second * 10}
+	doer := Decorate(httpClient, Logging(log.New(os.Stdout, "", log.LstdFlags)))
+
+	client := NewClient(doer, SetAPIKey(apiKey))
+
+	records, _, err := client.Records.Get(testDomain, testDomain, "CAA")
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, a := range records.Answers {
+		fmt.Println(a)
+	}
+
+	answer := dns.NewCAAAnswer(0, "issue", "globalchicken.com")
+	records.AddAnswer(answer)
+
+	response, err := client.Records.Update(records)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	println(response)
+
+
+
+}

--- a/rest/record_test.go
+++ b/rest/record_test.go
@@ -1,3 +1,5 @@
+// +build !integrationtest
+
 package rest
 
 import (
@@ -14,6 +16,10 @@ import (
 func TestCaaRecordIntegrationTest(t *testing.T){
 	apiKey := os.Getenv("NS1_APIKEY")
 	testDomain := os.Getenv("NS1_TESTDOMAIN")
+
+	if apiKey == "" || testDomain == "" {
+		return
+	}
 
 	httpClient := &http.Client{Timeout: time.Second * 10}
 	doer := Decorate(httpClient, Logging(log.New(os.Stdout, "", log.LstdFlags)))


### PR DESCRIPTION
Related to 
* https://github.com/terraform-providers/terraform-provider-ns1/issues/10
* https://github.com/ns1/ns1-go/issues/38

Swaps out the use of string[] for the record data for empty interface to avoid parsing issues caused by the API returning variable string/int parsing.

* I've added a zone example to `rest/_examples/zones.go`
* Changed all record data types in `rest/model/dns/answer.go`
* Added new method `NewCAAAnswer(flag int, tag string, value string) *Answer `
* Created an integration test (could do with full coverage via integration test considering the source of the error is the way the api functions per type) for the CAA record in `rest/record_test.go`

I've added a build feature tag (integrationtest) to the integration test as it requires 2 env vars setting; I used this to validate the change against our account.
