### PR TITLE
INT-62: set secondary disabled on MakePrimary

### DIFF
--- a/rest/model/dns/example_test.go
+++ b/rest/model/dns/example_test.go
@@ -47,6 +47,10 @@ func ExampleZone_MakePrimary() {
 	//         "notify": true
 	//       }
 	//     ]
+	//   },
+	//   "secondary": {
+	//     "error": null,
+	//     "enabled": false
 	//   }
 	// }
 

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -118,7 +118,7 @@ func NewZone(zone string) *Zone {
 // MakePrimary enables Primary, disables Secondary, and sets primary's
 // Secondaries to all provided ZoneSecondaryServers
 func (z *Zone) MakePrimary(secondaries ...ZoneSecondaryServer) {
-	z.Secondary = nil
+	z.Secondary = &ZoneSecondary{Enabled: false}
 	z.Primary = &ZonePrimary{
 		Enabled:     true,
 		Secondaries: secondaries,


### PR DESCRIPTION
Setting to nil means the API gets no secondary key, and we can end up
with both primary and secondary enabled.