### PR TITLE
INBOX-344: make pagination match standard behavior a bit more

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/rest/client.go
+++ b/rest/client.go
@@ -141,7 +141,9 @@ func SetFollowPagination(shouldFollow bool) func(*Client) {
 	return func(c *Client) { c.FollowPagination = shouldFollow }
 }
 
-// Do satisfies the Doer interface.
+// Do satisfies the Doer interface. resp will be nil if a non-HTTP error
+// occurs, otherwise it is available for inspection when the error reflects a
+// non-2XX response.
 func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -172,7 +174,8 @@ type NextFunc func(v *interface{}, uri string) (*http.Response, error)
 
 // DoWithPagination Does, and follows Link headers for pagination. The returned
 // Response is from the last URI visited - either the last page, or one that
-// responded with a non-2XX status.
+// responded with a non-2XX status. If a non-HTTP error occurs, resp will be
+// nil.
 func (c Client) DoWithPagination(req *http.Request, v interface{}, f NextFunc) (*http.Response, error) {
 	resp, err := c.Do(req, v)
 	if err != nil {

--- a/rest/client.go
+++ b/rest/client.go
@@ -170,20 +170,21 @@ func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 // NextFunc knows how to get and parse additional info from uri into v.
 type NextFunc func(v *interface{}, uri string) (*http.Response, error)
 
-// DoWithPagination Does, and follows Link headers for pagination. Preserves
-// and returns the _first_ http.Response (to match Do).
+// DoWithPagination Does, and follows Link headers for pagination. The returned
+// Response is from the last URI visited - either the last page, or one that
+// responded with a non-2XX status.
 func (c Client) DoWithPagination(req *http.Request, v interface{}, f NextFunc) (*http.Response, error) {
 	resp, err := c.Do(req, v)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 	nextURI := ParseLink(resp.Header.Get("Link")).Next()
 	for nextURI != "" {
-		nextResp, err := f(&v, nextURI)
+		resp, err = f(&v, nextURI)
 		if err != nil {
-			return nil, err
+			return resp, err
 		}
-		nextURI = ParseLink(nextResp.Header.Get("Link")).Next()
+		nextURI = ParseLink(resp.Header.Get("Link")).Next()
 	}
 	return resp, nil
 }
@@ -347,9 +348,7 @@ func (c *Client) getURI(v interface{}, uri string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Do(req, v)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	// For non-2XX responses, Do returns the response as well as an error, for
+	// other errs, resp will be nil. Caller's responsibility to sort that out.
+	return c.Do(req, v)
 }

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -90,7 +90,7 @@ func TestClient_DoWithHTTPClientError(t *testing.T) {
 }
 
 func TestClient_DoWithNon2XXResponse(t *testing.T) {
-	// It should return a pointer to the response, and a poiner to Error (with
+	// It should return a pointer to the response, and a pointer to Error (with
 	// the response)
 	httpClient := mockHTTPClient{}
 	client := NewClient(&httpClient, SetEndpoint(""))
@@ -157,6 +157,43 @@ func TestClient_DoWithPagination(t *testing.T) {
 
 	assert.Equal(t, &nextResp, resp)
 	assert.Nil(t, err)
+}
+
+func TestClient_getURI(t *testing.T) {
+	// It should delegate to client.Do
+	httpClient := mockHTTPClient{}
+	client := NewClient(&httpClient, SetEndpoint(""))
+
+	mockResp := http.Response{
+		Body: ioutil.NopCloser(bytes.NewBufferString("{}")),
+		StatusCode: 200,
+	}
+	httpClient.On("Do", mock.Anything).Return(&mockResp, nil)
+
+	var v interface{}
+	resp, err := client.getURI(v, "http://example.com")
+
+	assert.Equal(t, &mockResp, resp)
+	assert.Nil(t, err)
+}
+
+func TestClient_getURIWithNon2XXResponse(t *testing.T) {
+	// It should return a pointer to the response, and a pointer to Error (with
+	// the response
+	httpClient := mockHTTPClient{}
+	client := NewClient(&httpClient, SetEndpoint(""))
+
+	mockResp := http.Response{
+		Body: ioutil.NopCloser(bytes.NewBufferString("{}")),
+		StatusCode: 418,
+	}
+	httpClient.On("Do", mock.Anything).Return(&mockResp, nil)
+
+	var v interface{}
+	resp, err := client.getURI(v, "http://example.com")
+
+	assert.Equal(t, &mockResp, resp)
+	assert.Equal(t, &Error{Resp: &mockResp}, err)
 }
 
 type mockHTTPClient struct {

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -1,11 +1,19 @@
 package rest
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-func TestRateLimit(t *testing.T) {
+func TestClient_RateLimit(t *testing.T) {
 	r := RateLimit{
 		Limit:     10,
 		Remaining: 10,
@@ -42,4 +50,129 @@ func TestRateLimit(t *testing.T) {
 	if r.WaitTimeRemaining() != (time.Duration(10) * time.Second) {
 		t.Error("WaitTimeRemaining is wrong duration ", r.WaitTimeRemaining())
 	}
+}
+
+func TestClient_Do(t *testing.T) {
+	// It should return the response without error
+	httpClient := mockHTTPClient{}
+	client := NewClient(&httpClient, SetEndpoint(""))
+	req, _ := http.NewRequest("GET", "http://example.com", new(bytes.Buffer))
+
+	mockResp := http.Response{
+		Body: ioutil.NopCloser(bytes.NewBufferString("{}")),
+		StatusCode: 200,
+	}
+	httpClient.On("Do", req).Return(&mockResp, nil)
+
+	resp, err := client.Do(req, "")
+
+	httpClient.AssertExpectations(t)
+
+	assert.Equal(t, &mockResp, resp)
+	assert.Nil(t, err)
+}
+
+func TestClient_DoWithHTTPClientError(t *testing.T) {
+	// It should return nil response and the error
+	httpClient := mockHTTPClient{}
+	client := NewClient(&httpClient, SetEndpoint(""))
+	req, _ := http.NewRequest("GET", "http://example.com", new(bytes.Buffer))
+
+	mockError := errors.New("Some Error")
+	httpClient.On("Do", req).Return(nil, mockError)
+
+	resp, err := client.Do(req, "")
+
+	httpClient.AssertExpectations(t)
+
+	assert.Nil(t, resp)
+	assert.Equal(t, mockError, err)
+}
+
+func TestClient_DoWithNon2XXResponse(t *testing.T) {
+	// It should return a pointer to the response, and a poiner to Error (with
+	// the response)
+	httpClient := mockHTTPClient{}
+	client := NewClient(&httpClient, SetEndpoint(""))
+	req, _ := http.NewRequest("GET", "http://example.com", new(bytes.Buffer))
+
+	mockResp := http.Response{
+		Body: ioutil.NopCloser(bytes.NewBufferString("")),
+		StatusCode: 404,
+	}
+	httpClient.On("Do", req).Return(&mockResp, nil)
+
+	resp, err := client.Do(req, "")
+
+	httpClient.AssertExpectations(t)
+
+	assert.Equal(t, &mockResp, resp)
+	assert.Equal(t, &Error{Resp: &mockResp}, err)
+}
+
+func TestClient_DoWithNonJSONResponse(t *testing.T) {
+	// It should return a nil response, and the error from JSON Decoder
+	httpClient := mockHTTPClient{}
+	client := NewClient(&httpClient, SetEndpoint(""))
+	req, _ := http.NewRequest("GET", "http://example.com", new(bytes.Buffer))
+
+	mockResp := http.Response{
+		Body: ioutil.NopCloser(bytes.NewBufferString("INVALID")),
+		StatusCode: 200,
+	}
+	httpClient.On("Do", req).Return(&mockResp, nil)
+
+	resp, err := client.Do(req, "")
+
+	httpClient.AssertExpectations(t)
+
+	assert.Nil(t, resp)
+	assert.IsType(t, &json.SyntaxError{}, err)
+}
+
+func TestClient_DoWithPagination(t *testing.T) {
+	// It should call nextFunc
+	// It should return the last response without error
+	httpClient := mockHTTPClient{}
+	client := NewClient(&httpClient, SetEndpoint(""))
+
+	req, _ := http.NewRequest("GET", "http://example.com", new(bytes.Buffer))
+	firstResp := http.Response{
+		Body: ioutil.NopCloser(bytes.NewBufferString("{}")),
+		Header: http.Header{"Link": []string{`<http://example.com/?after=1&limit=2>; rel="next"`}},
+		StatusCode: 200,
+	}
+	nextResp := http.Response{
+		Body: ioutil.NopCloser(bytes.NewBufferString("{}")),
+		StatusCode: 200,
+	}
+	var v interface{}
+
+	httpClient.On("Do", req).Return(&firstResp, nil)
+	httpClient.On("nextFunc", &v, "http://example.com/?after=1&limit=2").Return(&nextResp, nil)
+
+	resp, err := client.DoWithPagination(req, v, httpClient.nextFunc)
+
+	httpClient.AssertExpectations(t)
+
+	assert.Equal(t, &nextResp, resp)
+	assert.Nil(t, err)
+}
+
+type mockHTTPClient struct {
+	mock.Mock
+}
+
+func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	args := c.Called(req)
+	if res := args.Get(0); res == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+// Hanging this off of mockHTTPClient for convent access to mocking stuff
+func (c *mockHTTPClient) nextFunc(v *interface{}, uri string) (*http.Response, error) {
+	args := c.Called(v, uri)
+	return args.Get(0).(*http.Response), args.Error(1)
 }

--- a/rest/headers_test.go
+++ b/rest/headers_test.go
@@ -1,0 +1,18 @@
+package rest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLinks(t *testing.T) {
+	linkURI := "http://example.com?page=2&limit=10"
+
+	links := ParseLink(fmt.Sprintf(`<%s>; rel="next"`, linkURI))
+	assert.Equal(t, 1, len(links))
+
+	next := links.Next()
+	assert.Equal(t, linkURI, next)
+}

--- a/rest/zone.go
+++ b/rest/zone.go
@@ -148,7 +148,7 @@ func (s *ZonesService) nextZones(v *interface{}, uri string) (*http.Response, er
 	tmpZl := []*dns.Zone{}
 	resp, err := s.client.getURI(&tmpZl, uri)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 	zoneList, ok := (*v).(*[]*dns.Zone)
 	if !ok {
@@ -166,7 +166,7 @@ func (s *ZonesService) nextRecords(v *interface{}, uri string) (*http.Response, 
 	var tmpZone dns.Zone
 	resp, err := s.client.getURI(&tmpZone, uri)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 	zone, ok := (*v).(*dns.Zone)
 	if !ok {


### PR DESCRIPTION
On HTTP error, the Do handler returns the response as well as the
error, and people were using that. In lieu of a breaking change,
we emulate this behavior as closely as we can in DoWithPagination.

DoWithPagination:
  * Return the response as well as the error, on HTTP Error
  * We now clobber the old responses as we traverse pages. On HTTP
    error, the response will match the error. Without error, the
    response will be the _last_ page of results.

Tried to exercise this in unit tests. Since it's a bit subtle, it
would be nice if a test broke if we accidentally change behavior.

Also:
  * Refactored the little "mockAPI" stuff for more generic use
  * Add a litle unit test for the hearer parsing funcs