### PR TITLE
INBOX-344: force HTTPS when following Link headers

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -181,13 +181,17 @@ func (c Client) DoWithPagination(req *http.Request, v interface{}, f NextFunc) (
 	if err != nil {
 		return resp, err
 	}
-	nextURI := ParseLink(resp.Header.Get("Link")).Next()
+
+	// See PLAT-188
+	forceHTTPS := c.Endpoint.Scheme == "https"
+
+	nextURI := ParseLink(resp.Header.Get("Link"), forceHTTPS).Next()
 	for nextURI != "" {
 		resp, err = f(&v, nextURI)
 		if err != nil {
 			return resp, err
 		}
-		nextURI = ParseLink(resp.Header.Get("Link")).Next()
+		nextURI = ParseLink(resp.Header.Get("Link"), forceHTTPS).Next()
 	}
 	return resp, nil
 }

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -133,8 +133,9 @@ func TestClient_DoWithNonJSONResponse(t *testing.T) {
 func TestClient_DoWithPagination(t *testing.T) {
 	// It should call nextFunc
 	// It should return the last response without error
+	// It should not set HTTPS on the Link when endpoint is HTTP
 	httpClient := mockHTTPClient{}
-	client := NewClient(&httpClient, SetEndpoint(""))
+	client := NewClient(&httpClient, SetEndpoint("http://"))
 
 	req, _ := http.NewRequest("GET", "http://example.com", new(bytes.Buffer))
 	firstResp := http.Response{

--- a/rest/headers.go
+++ b/rest/headers.go
@@ -38,7 +38,7 @@ func (l Links) Next() string {
 
 // ParseLink parses a Link header value into a Links, mainly cribbed from:
 // https://github.com/peterhellberg/link/blob/master/link.go
-func ParseLink(s string) Links {
+func ParseLink(s string, forceHTTPS bool) Links {
 	if s == "" {
 		return nil
 	}
@@ -58,8 +58,14 @@ func ParseLink(s string) Links {
 
 		// Make sure we have a reasonable URL
 		uri := ""
-		if _, err := url.ParseRequestURI(pieces[1]); err == nil {
-			uri = pieces[1]
+		if url, err := url.ParseRequestURI(pieces[1]); err == nil {
+
+			// See PLAT-188
+			if forceHTTPS && url.Scheme == "http" {
+				url.Scheme = "https"
+			}
+
+			uri = url.String()
 		}
 
 		link := &Link{URI: uri, Extra: map[string]string{}}

--- a/rest/headers.go
+++ b/rest/headers.go
@@ -38,6 +38,7 @@ func (l Links) Next() string {
 
 // ParseLink parses a Link header value into a Links, mainly cribbed from:
 // https://github.com/peterhellberg/link/blob/master/link.go
+// The forceHTTPS parameter will rewrite any HTTP URLs it finds to HTTPS.
 func ParseLink(s string, forceHTTPS bool) Links {
 	if s == "" {
 		return nil

--- a/rest/headers_test.go
+++ b/rest/headers_test.go
@@ -2,17 +2,29 @@ package rest
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseLinks(t *testing.T) {
+func TestHeaders_ParseLinks(t *testing.T) {
 	linkURI := "http://example.com?page=2&limit=10"
 
-	links := ParseLink(fmt.Sprintf(`<%s>; rel="next"`, linkURI))
+	links := ParseLink(fmt.Sprintf(`<%s>; rel="next"`, linkURI), false)
 	assert.Equal(t, 1, len(links))
 
 	next := links.Next()
 	assert.Equal(t, linkURI, next)
+}
+
+func TestHeaders_ParseLinksWithForceHTTPS(t *testing.T) {
+	// It should replace HTTP with HTTPS in the urls
+	linkURI := "http://example.com?page=2&limit=10"
+
+	links := ParseLink(fmt.Sprintf(`<%s>; rel="next"`, linkURI), true)
+	assert.Equal(t, 1, len(links))
+
+	next := links.Next()
+	assert.Equal(t, strings.Replace(linkURI, "http://", "https://", 1), next)
 }


### PR DESCRIPTION
When the Client endpoint is set to an HTTPS URL, rewrite any HTTP Link
URL to HTTPS.