### PR TITLE
issue-79: strip leading and trailing dot characters 

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -35,9 +35,12 @@ func (r Record) String() string {
 // NewRecord takes a zone, domain and record type t and creates a *Record with
 // UseClientSubnet: true & empty Answers.
 func NewRecord(zone string, domain string, t string) *Record {
+	domain = removeEnclosingDots(domain)
+	zone = removeEnclosingDots(zone)
 	if !strings.HasSuffix(domain, zone) {
 		domain = fmt.Sprintf("%s.%s", domain, zone)
 	}
+
 	return &Record{
 		Meta:    &data.Meta{},
 		Zone:    zone,
@@ -74,4 +77,20 @@ func (r *Record) AddFilter(fil *filter.Filter) {
 	}
 
 	r.Filters = append(r.Filters, fil)
+}
+
+// Remove any dot (.) character prefix or suffix of the given string.
+// This is useful because dns names often end in '.' characters to signify
+// the root of the DNS tree.  But NS1 API does not support this.
+//
+// In other cases a domain or zone may be passed in with a preceding dot (.)
+// character which would likewise lead the system to fail.
+func removeEnclosingDots(inputString string) string {
+	if strings.HasSuffix(inputString, ".") {
+		inputString = inputString[0 : len(inputString)-1]
+	}
+	if strings.HasPrefix(inputString,"."){
+		inputString = inputString[1:len(inputString)]
+	}
+	return inputString
 }

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -35,8 +35,8 @@ func (r Record) String() string {
 // NewRecord takes a zone, domain and record type t and creates a *Record with
 // UseClientSubnet: true & empty Answers.
 func NewRecord(zone string, domain string, t string) *Record {
-	domain = removeEnclosingDots(domain)
-	zone = removeEnclosingDots(zone)
+	domain = RemoveEnclosingDots(domain)
+	zone = RemoveEnclosingDots(zone)
 	if !strings.HasSuffix(domain, zone) {
 		domain = fmt.Sprintf("%s.%s", domain, zone)
 	}
@@ -85,7 +85,7 @@ func (r *Record) AddFilter(fil *filter.Filter) {
 //
 // In other cases a domain or zone may be passed in with a preceding dot (.)
 // character which would likewise lead the system to fail.
-func removeEnclosingDots(inputString string) string {
+func RemoveEnclosingDots(inputString string) string {
 	if strings.HasSuffix(inputString, ".") {
 		inputString = inputString[0 : len(inputString)-1]
 	}

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -1,0 +1,42 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveEnclosingDots(t *testing.T) {
+	/*
+		Given either or both a leading and/or trailing dot, we expect the RemoveEnclosingDots() function will
+		remove the leading/trailing dots and return the sanitized string.  However, we do not expect that more than
+		one leading/trailing dot will be sanitized (as this would most likely mask an error condition for the caller).
+	*/
+	assert.Equal(t, RemoveEnclosingDots(".f"), "f", "leading dot should have been removed")
+	assert.Equal(t, RemoveEnclosingDots("f."), "f", "trailing dot should have been removed")
+	assert.Equal(t, RemoveEnclosingDots(".f."), "f", "leading and trailing dots should have been removed")
+	assert.NotEqual(t, RemoveEnclosingDots("..f.."), "f", "leading and trailing dots should have been removed")
+}
+
+func TestNewRecordWithEnclosingDots(t *testing.T) {
+	/*
+		Given a domain and zone, we expect that New Record will append the zone to the end of the domain, stripping
+		any single leading/trailing dots, and the result would be a Fully Qualified Domain Name (FQDN) which is
+		acceptable to the NS1 API.
+	*/
+	domain := "my-service.my-subdomain"
+	zone := "my-domain.tld"
+	expectedFqdn := fmt.Sprintf("%s.%s", domain, zone)
+
+	badDomain := fmt.Sprintf(".%s.", domain)
+	badZone := fmt.Sprintf(".%s.", zone)
+
+	GoodRecord := NewRecord(zone, domain, "CNAME")
+	BadRecord := NewRecord(badZone, badDomain, "CNAME")
+
+	assert.Equal(t, GoodRecord.Zone , BadRecord.Zone, "zone not properly sanitized (enclosing dots)")
+	assert.Equal(t, GoodRecord.Domain, BadRecord.Domain, "domain not properly sanitized (enclosing dots)")
+	assert.Equal(t, GoodRecord.Domain, expectedFqdn, "GoodRecord.Domain does not match expectedFqdn")
+	assert.Equal(t, BadRecord.Domain, expectedFqdn, "BadRecord.Domain does not match expectedFqdn")
+}


### PR DESCRIPTION
**Problem:**
As reported in _ns1-go_ [issue #79](https://github.com/ns1/ns1-go/issues/79) and _terraform-provider-ns1_ [issue #38](https://github.com/terraform-providers/terraform-provider-ns1/issues/38), certain use cases exist where a preceding or trailing dot character may exist in a domain or zone.  When passed to _ns1/ns1-go_, the _NewRecord()_ function will concatenate the domain and zone without stripping the dot character and result in something like domain..zone.  This results in an HTTP/400 error from NS1 API, since it cannot handle trailing dot characters.

For example, Amazon AWS Certificate Manager (ACM) generates DNS validation records which end in a trailing dot.  Because of the bug addressed in this ticket, _terraform-provider-ns1_ generates calls _NewRecord()_ with the dot-terminated domain and zone, and _NewRecord()_ produces a malformed request.

**Solution:**
We have added a function _removeEnclosingDots()_ which is called by _NewRecord()_ to strip any preceding or trailing dot characters prior to evaluating _.HasSuffix()_.