### PR TITLE
INT-90: support URLFWD records

### DIFF
--- a/rest/model/dns/answer.go
+++ b/rest/model/dns/answer.go
@@ -142,3 +142,49 @@ func NewCAAAnswer(flag int, tag, value string) *Answer {
 		Rdata: []string{strconv.Itoa(flag), tag, value},
 	}
 }
+
+// NewURLFWDAnswer creates an Answer for URLFWD record.
+func NewURLFWDAnswer(from, to string, redirectType, pathForwardingMode, queryForwarding int) *Answer {
+	return &Answer{
+		Meta: &data.Meta{},
+		Rdata: []string{
+			from,
+			to,
+			strconv.Itoa(redirectType),
+			strconv.Itoa(pathForwardingMode),
+			strconv.Itoa(queryForwarding),
+		},
+	}
+}
+
+// return Answer with Rdata as list of interface, with elements of the correct
+// type for API.
+func prepareURLFWDAnswer(a *Answer) (interface{}, error) {
+	type Alias Answer
+	redirectType, err := strconv.Atoi(a.Rdata[2])
+	if err != nil {
+		return nil, err
+	}
+	pathForwardingMode, err := strconv.Atoi(a.Rdata[3])
+	if err != nil {
+		return nil, err
+	}
+	queryForwarding, err := strconv.Atoi(a.Rdata[4])
+	if err != nil {
+		return nil, err
+	}
+	prepared := &struct {
+		Rdata []interface{} `json:"answer"`
+		*Alias
+	}{
+		Rdata: []interface{}{
+			a.Rdata[0],
+			a.Rdata[1],
+			redirectType,
+			pathForwardingMode,
+			queryForwarding,
+		},
+		Alias: (*Alias)(a),
+	}
+	return prepared, nil
+}

--- a/rest/model/dns/answer_test.go
+++ b/rest/model/dns/answer_test.go
@@ -35,14 +35,30 @@ func TestUnmarshalAnswer(t *testing.T) {
 	assert.Equal(t, "us-east", a.RegionName, "Incorrect region")
 }
 
-func TestNewCAAAnswer(t *testing.T) {
-	expected := &Answer{
-		Meta: &data.Meta{},
-		Rdata: []string{
-			"0",
-			"issue",
-			"ca.test.zone",
+var newAnswerCases = []struct {
+	name string
+	in   *Answer
+	out  *Answer
+}{
+	{
+		"testCAAAnswer",
+		NewCAAAnswer(0, "issue", "ca.test.zone"),
+		&Answer{Meta: &data.Meta{}, Rdata: []string{"0", "issue", "ca.test.zone"}},
+	},
+	{
+		"testURLFWDAnswer",
+		NewURLFWDAnswer("/", "https://google.com", 302, 2, 0),
+		&Answer{
+			Meta:  &data.Meta{},
+			Rdata: []string{"/", "https://google.com", "302", "2", "0"},
 		},
+	},
+}
+
+func TestNewAnswers(t *testing.T) {
+	for _, tt := range newAnswerCases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.in, tt.out, tt.name)
+		})
 	}
-	assert.Equal(t, expected, NewCAAAnswer(0, "issue", "ca.test.zone"))
 }

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -74,4 +75,41 @@ func (r *Record) AddFilter(fil *filter.Filter) {
 	}
 
 	r.Filters = append(r.Filters, fil)
+}
+
+// MarshalJSON attempts to convert any Rdata elements that cannot be passed as
+// strings to the API to their correct type.
+func (r *Record) MarshalJSON() ([]byte, error) {
+	if r.Type == "URLFWD" {
+		prepared, err := prepareURLFWDRecord(r)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(prepared)
+	}
+	// avoid an infinite loop
+	type Alias Record
+	return json.Marshal((*Alias)(r))
+}
+
+// returns Record with Answers as list of interface, with the Answer RData
+// typed correctly for the API.
+func prepareURLFWDRecord(r *Record) (interface{}, error) {
+	as := []interface{}{}
+	for i := range r.Answers {
+		a, err := prepareURLFWDAnswer(r.Answers[i])
+		if err != nil {
+			return nil, err
+		}
+		as = append(as, a)
+	}
+	type Alias Record
+	prepared := &struct {
+		Answers []interface{} `json:"answers"`
+		*Alias
+	}{
+		Answers: as,
+		Alias:   (*Alias)(r),
+	}
+	return prepared, nil
 }

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -1,0 +1,47 @@
+package dns
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+var marshalRecordCases = []struct {
+	name    string
+	record  *Record
+	answers []*Answer
+	out     []byte
+}{
+	{
+		"marshalCAARecord",
+		NewRecord("example.com", "caa.example.com", "CAA"),
+		[]*Answer{NewCAAAnswer(0, "issue", "letsencrypt.org")},
+		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}],"filters":[]}`),
+	},
+	{
+		"marshalURLFWDRecord",
+		NewRecord("example.com", "fwd.example.com", "URLFWD"),
+		[]*Answer{
+			NewURLFWDAnswer("/net", "https://example.net", 301, 1, 1),
+			NewURLFWDAnswer("/org", "https://example.org", 302, 2, 0),
+		},
+		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD","filters":[]}`),
+	},
+}
+
+func TestMarshalRecords(t *testing.T) {
+	for _, tt := range marshalRecordCases {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := range tt.answers {
+				tt.record.AddAnswer(tt.answers[i])
+			}
+			result, err := json.Marshal(tt.record)
+			if err != nil {
+				t.Error(err)
+			}
+			if bytes.Compare(result, tt.out) != 0 {
+				t.Errorf("got %q, want %q", result, tt.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In previous cases, the API accepts strings, but has the correct value
types in the response. For URLFWD, the API requires correct types for
the aswer values on the inbound side as well.

* Add NewURLFWDAnswer convenience function. This allows passing args
  with the correct types (which are then coverted to all strings).
  NewAnswer can also be used, with the data passed as []string
* Custom MarshalJSON handles translating URLFWD's RData into API-speak.
  Response values for URLFWD are already handled with existing unmarshal
  logic.
* Started a table-driven test case for records. Made answer tests
  table-driven and added a URLFWD case