### PR TITLE
change ip whitelists to use a zero val on serialization

### DIFF
--- a/rest/model/account/apikey.go
+++ b/rest/model/account/apikey.go
@@ -10,6 +10,6 @@ type APIKey struct {
 	Name              string         `json:"name"`
 	TeamIDs           []string       `json:"teams"`
 	Permissions       PermissionsMap `json:"permissions"`
-	IPWhitelist       []string       `json:"ip_whitelist,omitempty"`
+	IPWhitelist       []string       `json:"ip_whitelist"`
 	IPWhitelistStrict bool           `json:"ip_whitelist_strict"`
 }

--- a/rest/model/account/team.go
+++ b/rest/model/account/team.go
@@ -5,12 +5,12 @@ type Team struct {
 	ID          string         `json:"id,omitempty"`
 	Name        string         `json:"name"`
 	Permissions PermissionsMap `json:"permissions"`
-	IPWhitelist []IPWhitelist  `json:"ip_whitelist,omitempty"`
+	IPWhitelist []IPWhitelist  `json:"ip_whitelist"`
 }
 
 // IPWhitelist wraps the IP whitelist for Teams.
 type IPWhitelist struct {
-	ID     string   `json:"id"`
+	ID     string   `json:"id,omitempty"`
 	Name   string   `json:"name"`
 	Values []string `json:"values"`
 }

--- a/rest/model/account/user.go
+++ b/rest/model/account/user.go
@@ -12,7 +12,7 @@ type User struct {
 	TeamIDs              []string             `json:"teams"`
 	Notify               NotificationSettings `json:"notify"`
 	Permissions          PermissionsMap       `json:"permissions"`
-	IPWhitelist          []string             `json:"ip_whitelist,omitempty"`
+	IPWhitelist          []string             `json:"ip_whitelist"`
 	IPWhitelistStrict    bool                 `json:"ip_whitelist_strict"`
 	TwoFactorAuthEnabled bool                 `json:"2fa_enabled"`
 	InviteToken          string               `json:"invite_token,omitempty"`


### PR DESCRIPTION
had to make this change because if no value is sent through, apid doesn't remove the whitelist, so Terraform was unable to delete ip whitelists properly.