### PR TITLE
handle pulsar data in record answer meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.3.0 (Unreleased)
+## 2.4.0 (Unreleased)
+
+## 2.3.0 (March 19, 2020)
+FEATURES:
+* Support for pulsar metadata on answers
 
 ## 2.2.1 (Febuary 14, 2020)
 BUG FIXES

--- a/rest/client.go
+++ b/rest/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	clientVersion = "2.2.1"
+	clientVersion = "2.3.0"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true

--- a/rest/model/data/meta.go
+++ b/rest/model/data/meta.go
@@ -16,6 +16,13 @@ type FeedPtr struct {
 	FeedID string `json:"feed,omitempty"`
 }
 
+// PulsarMeta is currently only used for validation
+type PulsarMeta struct {
+	JobID     string  `json:"job_id,omitempty"`
+	Bias      string  `json:"bias,omitempty"`
+	A5MCutoff float64 `json:"a5m_cutoff,omitempty"`
+}
+
 // Meta contains information on an entity's metadata table. Metadata key/value
 // pairs are used by a record's filter pipeline during a dns query.
 // All values can be a feed id as well, indicating real-time updates of these values.
@@ -51,9 +58,8 @@ type Meta struct {
 	// float64 or FeedPtr.
 	LoadAvg interface{} `json:"loadavg,omitempty"`
 
-	// The Job ID of a Pulsar telemetry gathering job and routing granularities
-	// to associate with.
-	// string or FeedPtr.
+	// The Job ID of a Pulsar telemetry gathering job and associated metadata.
+	// list of PulsarMeta
 	Pulsar interface{} `json:"pulsar,omitempty"`
 
 	// GEOGRAPHICAL
@@ -177,6 +183,10 @@ func FormatInterface(i interface{}) string {
 		slc := make([]string, 0)
 		for _, s := range v {
 			switch ss := s.(type) {
+			// Pulsar
+			case map[string]interface{}:
+				data, _ := json.Marshal(v)
+				return string(data)
 			case string:
 				slc = append(slc, ss)
 			// The ASN field specifically is returned from the API as an integer,
@@ -274,6 +284,11 @@ func MetaFromMap(m map[string]interface{}) *Meta {
 					fv.Set(reflect.ValueOf(v.(string)))
 				} else {
 					fv.Set(reflect.ValueOf(ParseType(v.(string))))
+				}
+			case "Pulsar":
+				var pulsars []map[string]interface{}
+				if err := json.Unmarshal([]byte(v.(string)), &pulsars); err == nil {
+					fv.Set(reflect.ValueOf(pulsars))
 				}
 			default:
 				fv.Set(reflect.ValueOf(ParseType(v.(string))))
@@ -442,6 +457,34 @@ func validateNoteLength(v reflect.Value) error {
 	return nil
 }
 
+func validatePulsar(v reflect.Value) error {
+	var pulsars []*PulsarMeta
+
+	switch v.Kind() {
+	case reflect.Slice:
+		// Slice from API
+		bs, err := json.Marshal(v.Interface())
+		if err != nil {
+			return fmt.Errorf("pulsar: unexpected value: `%v`", v.Interface())
+		}
+		if err := json.Unmarshal(bs, &pulsars); err != nil {
+			return fmt.Errorf("pulsar: invalid value: `%v`", v.Interface())
+		}
+	case reflect.String:
+		// String from terraform
+		if err := json.Unmarshal([]byte(v.String()), &pulsars); err != nil {
+			return fmt.Errorf("pulsar: invalid value: `%v`", v.String())
+		}
+	}
+
+	for _, p := range pulsars {
+		if p.JobID == "" {
+			return fmt.Errorf("pulsar Job ID is required")
+		}
+	}
+	return nil
+}
+
 // checkFuncs is shorthand for returning a slice of functions that take a reflect.Value and return an error
 func checkFuncs(f ...func(v reflect.Value) error) []func(v reflect.Value) error {
 	return f
@@ -467,7 +510,7 @@ var validationMap = map[string]metaValidation{
 		func(v reflect.Value) error {
 			return validatePositiveNumber("LoadAvg", v)
 		})},
-	"Pulsar":     {kinds(reflect.String), nil},
+	"Pulsar":     {kinds(reflect.String, reflect.Slice), checkFuncs(validatePulsar)},
 	"Latitude":   {kinds(reflect.Float64, reflect.Int), checkFuncs(validateLatLong)},
 	"Longitude":  {kinds(reflect.Float64, reflect.Int), checkFuncs(validateLatLong)},
 	"Georegion":  {kinds(reflect.String, reflect.Slice), checkFuncs(validateGeoregion)},


### PR DESCRIPTION
We've mixed some terraform specific stuff in here, so we have to
handle it as slices (from API responses) or strings (from terraform)

Added a PulsarMeta type, for validation only, as it's probably a
breaking change to mess with the type on Meta.