### PR TITLE
Exported mock API service

### DIFF
--- a/mockns1/doc.go
+++ b/mockns1/doc.go
@@ -1,4 +1,4 @@
-// This package provides utilities to run a mock service
+// Package mockns1 provides utilities to run a mock service
 // that emulates the NS1 API suitible for mock testing
 // code that relies on the gopkg.in/ns1/ns1-go.v2 pacakge
 package mockns1

--- a/mockns1/doc.go
+++ b/mockns1/doc.go
@@ -1,0 +1,4 @@
+// This package provides utilities to run a mock service
+// that emulates the NS1 API suitible for mock testing
+// code that relies on the gopkg.in/ns1/ns1-go.v2 pacakge
+package mockns1

--- a/mockns1/example_test.go
+++ b/mockns1/example_test.go
@@ -1,0 +1,38 @@
+package mockns1_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ns1/ns1-go.v2/mockns1"
+	api "gopkg.in/ns1/ns1-go.v2/rest"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+func Example() {
+	t := new(testing.T)
+
+	// Setup the mock service
+	mock, doer, err := mockns1.New(t)
+	require.Nil(t, err)
+
+	defer mock.Shutdown()
+
+	// Create your NS1 client and configure it for the mock service
+	ns1 := api.NewClient(doer, api.SetAPIKey("apikey"))
+	ns1.Endpoint, _ = url.Parse("https://" + mock.Address + "/v1/")
+
+	// Add your test case (zone list in this example)
+	require.Nil(t, mock.AddTestCase(http.MethodGet, "zones", http.StatusOK, nil, nil, "",
+		[]*dns.Zone{{Zone: "foo.bar"}}))
+
+	// Perform your tests
+	zones, _, err := ns1.Zones.List()
+	require.Nil(t, err)
+	require.Equal(t, 1, len(zones))
+	require.Equal(t, "foo.bar", zones[0].Zone)
+
+	// Output:
+}

--- a/mockns1/servehttp.go
+++ b/mockns1/servehttp.go
@@ -1,0 +1,111 @@
+package mockns1
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ServeHTTP is the request  handler for the mock service. This
+// should not be called directly in unit tests.
+func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.stopTimer()
+	defer s.startTimer()
+
+	if _, exists := s.tests[r.Method]; !exists {
+		notFoundResponse(w, "method")
+		return
+	}
+
+	tests, exists := s.tests[r.Method][r.RequestURI]
+	if !exists {
+		notFoundResponse(w, "uri")
+		return
+	}
+
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte( // nolint: errcheck
+			fmt.Sprintf(`{"message": "unable to read request body: %s`, err),
+		))
+		return
+	}
+
+	var test *testCase
+	for _, t := range tests {
+		if !assert.Equal(new(testifyT), t.request.body, body) {
+			continue
+		}
+
+		if !compareHeaders(t.request.headers, r.Header) {
+			continue
+		}
+
+		test = t
+		break
+	}
+
+	if test == nil {
+		notFoundResponse(w, "no test")
+		return
+	}
+
+	for k, vals := range test.response.headers {
+		w.Header().Set(k, vals[0])
+		for _, v := range vals[1:] {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.WriteHeader(test.status)
+	w.Write(test.response.body) // nolint: errcheck
+}
+
+func notFoundResponse(w http.ResponseWriter, reason string) {
+	msg := fmt.Sprintf(`{"message": "request not found: %s"}`, reason)
+	w.WriteHeader(http.StatusNotFound)
+	w.Write([]byte(msg)) // nolint: errcheck
+}
+
+func compareHeaders(a, b http.Header) bool {
+	for key := range a {
+		if !compareHeader(key, a, b) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareHeader(key string, a, b http.Header) bool {
+	if _, exists := b[key]; !exists {
+		return false
+	}
+
+	for _, v := range a[key] {
+		if !inList(v, b[key]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func inList(needle string, haystack []string) bool {
+	for _, straw := range haystack {
+		if straw == needle {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Stub "T" for use with github.com/stretchr/testify/assert tests
+type testifyT struct{}
+
+func (t *testifyT) Errorf(format string, args ...interface{}) {}

--- a/mockns1/servehttp.go
+++ b/mockns1/servehttp.go
@@ -37,8 +37,14 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var test *testCase
 	for _, t := range tests {
-		if !assert.Equal(new(testifyT), t.request.body, body) {
-			continue
+		if !t.request.json {
+			if !assert.Equal(new(testifyT), t.request.body, body) {
+				continue
+			}
+		} else {
+			if !assert.JSONEq(new(testifyT), string(t.request.body), string(body)) {
+				continue
+			}
 		}
 
 		if !compareHeaders(t.request.headers, r.Header) {

--- a/mockns1/servehttp_test.go
+++ b/mockns1/servehttp_test.go
@@ -1,0 +1,123 @@
+package mockns1_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ns1/ns1-go.v2/mockns1"
+)
+
+func TestServeHTTP(t *testing.T) {
+	t.Run("ServeHTTP", func(t *testing.T) {
+		mock, _, err := mockns1.New(t)
+		require.Nil(t, err)
+		defer mock.Shutdown()
+
+		t.Run("Errors", func(t *testing.T) {
+			t.Run("Method", func(t *testing.T) {
+				mw := &mockWriter{buf: bytes.NewBufferString("")}
+				req := &http.Request{Method: http.MethodOptions}
+
+				mock.ServeHTTP(mw, req)
+				require.Equal(t, http.StatusNotFound, mw.status, mw.buf.String())
+				require.Equal(t, `{"message": "request not found: method"}`, mw.buf.String())
+			})
+
+			t.Run("URI", func(t *testing.T) {
+				mw := &mockWriter{buf: bytes.NewBufferString("")}
+				req := &http.Request{
+					Method:     http.MethodGet,
+					RequestURI: "/test",
+				}
+
+				require.Nil(t, mock.AddTestCase(
+					http.MethodGet, "/test", http.StatusTeapot, nil, nil, "", "",
+				))
+
+				mock.ServeHTTP(mw, req)
+				require.Equal(t, http.StatusNotFound, mw.status, mw.buf.String())
+				require.Equal(t, `{"message": "request not found: uri"}`, mw.buf.String())
+			})
+
+			t.Run("Test", func(t *testing.T) {
+				mw := &mockWriter{buf: bytes.NewBufferString("")}
+				req := &http.Request{
+					Method:     http.MethodGet,
+					RequestURI: "/v1/bad/body",
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte("body"))),
+				}
+
+				require.Nil(t, mock.AddTestCase(
+					http.MethodGet, "/bad/body", http.StatusTeapot, nil, nil, "", "",
+				))
+
+				mock.ServeHTTP(mw, req)
+				require.Equal(t, http.StatusNotFound, mw.status, mw.buf.String())
+				require.Equal(t, `{"message": "request not found: no test"}`, mw.buf.String())
+			})
+		})
+
+		t.Run("Success", func(t *testing.T) {
+			t.Run("Header", func(t *testing.T) {
+				mw := &mockWriter{buf: bytes.NewBufferString("")}
+				req := &http.Request{
+					Method:     http.MethodGet,
+					RequestURI: "/v1/request/header",
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+					Header:     http.Header{},
+				}
+				req.Header.Set("x-test-header", "test-value")
+
+				hdrs := http.Header{}
+				hdrs.Set("x-test-header", "test-value")
+				require.Nil(t, mock.AddTestCase(
+					http.MethodGet, "/request/header", http.StatusOK, hdrs, nil, "",
+					"header match",
+				))
+
+				mock.ServeHTTP(mw, req)
+				require.Equal(t, http.StatusOK, mw.status, mw.buf.String())
+				require.Equal(t, "header match", mw.buf.String())
+			})
+
+			t.Run("Body", func(t *testing.T) {
+				mw := &mockWriter{buf: bytes.NewBufferString("")}
+				req := &http.Request{
+					Method:     http.MethodGet,
+					RequestURI: "/v1/request/body",
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte("body"))),
+				}
+
+				require.Nil(t, mock.AddTestCase(
+					http.MethodGet, "/request/body", http.StatusOK, nil, nil, "body",
+					"body match",
+				))
+
+				mock.ServeHTTP(mw, req)
+				require.Equal(t, http.StatusOK, mw.status, mw.buf.String())
+				require.Equal(t, "body match", mw.buf.String())
+			})
+		})
+	})
+}
+
+type mockWriter struct {
+	buf     *bytes.Buffer
+	headers http.Header
+	status  int
+}
+
+func (mw *mockWriter) Header() http.Header {
+	return mw.headers
+}
+
+func (mw *mockWriter) Write(data []byte) (int, error) {
+	return mw.buf.Write(data)
+}
+
+func (mw *mockWriter) WriteHeader(status int) {
+	mw.status = status
+}

--- a/mockns1/service.go
+++ b/mockns1/service.go
@@ -1,0 +1,81 @@
+package mockns1
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	api "gopkg.in/ns1/ns1-go.v2/rest"
+)
+
+// Service is a controller for a mock server suitable for responding to
+// gopkg.in/ns1/ns1-go.v2 client requests. This object should always be
+// initialized via the New() function.
+type Service struct {
+	// Address is set by New() to the listen address of the mock server
+	Address string
+
+	server *httptest.Server
+	tests  map[string]map[string][]*testCase // method, uri
+	tb     testing.TB
+}
+
+// New creates and starts a new TLS based *httptest.Server instance. As a
+// self signed certificate is being used by the server, your HTTP client
+// being used with your NS1 client needs to disable TLS verification. The
+// returned Doer is a *http.Client with TLS verification disable that
+// is appropriate for use.
+//
+// The mock service is compatible with both testing.B and testing.T instances
+// so that it may be used in benchmarking as well as testing. If a
+// testing.B instance is supplied the timer will be stopped for the
+// duration of the ServeHTTP() and AddTestCase() methods to minimise
+// the impact on your benchmark statistics.
+func New(tb testing.TB) (*Service, api.Doer, error) {
+	s := &Service{
+		tb:    tb,
+		tests: map[string]map[string][]*testCase{},
+	}
+
+	hc := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		}},
+	}
+
+	s.server = httptest.NewTLSServer(s)
+
+	u, err := url.Parse(s.server.URL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to parse server URL for address: %s", err)
+	}
+	s.Address = u.Host
+
+	return s, hc, nil
+}
+
+// Shutdown cleans up the mock instance
+func (s *Service) Shutdown() {
+	s.server.Close()
+}
+
+func (s *Service) startTimer() {
+	b, ok := s.tb.(*testing.B)
+	if !ok {
+		return
+	}
+
+	b.StartTimer()
+}
+
+func (s *Service) stopTimer() {
+	b, ok := s.tb.(*testing.B)
+	if !ok {
+		return
+	}
+
+	b.StopTimer()
+}

--- a/mockns1/service_test.go
+++ b/mockns1/service_test.go
@@ -1,0 +1,26 @@
+package mockns1_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ns1/ns1-go.v2/mockns1"
+)
+
+func TestService(t *testing.T) {
+	t.Run("New", func(t *testing.T) {
+		mock, doer, err := mockns1.New(t)
+		require.Nil(t, err)
+		require.IsType(t, new(http.Client), doer)
+		require.NotNil(t, mock)
+		require.NotEmpty(t, mock.Address)
+		mock.Shutdown()
+	})
+
+	t.Run("Shutdown", func(t *testing.T) {
+		mock, _, err := mockns1.New(t)
+		require.Nil(t, err)
+		require.NotPanics(t, mock.Shutdown)
+	})
+}

--- a/mockns1/testcase.go
+++ b/mockns1/testcase.go
@@ -1,0 +1,85 @@
+package mockns1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	status  int
+	request struct {
+		headers http.Header
+		body    []byte
+	}
+	response struct {
+		headers http.Header
+		body    []byte
+	}
+}
+
+// AddTestCase adds a new test case to the mock service. Test cases are
+// unique based on the method, uri, request headers, and request body.
+func (s *Service) AddTestCase(
+	method, uri string, returnStatus int,
+	requestHeaders, responseHeaders http.Header,
+	requestBody, responseBody interface{},
+) error {
+	s.stopTimer()
+	defer s.startTimer()
+
+	if !strings.HasPrefix(uri, "/v1/") {
+		uri = "/v1/" + uri
+	}
+	uri = strings.ReplaceAll(uri, "//", "/")
+
+	tc := &testCase{
+		status: returnStatus,
+	}
+	tc.request.headers = requestHeaders
+	tc.response.headers = responseHeaders
+
+	var err error
+	if tc.request.body, err = convertBody(requestBody); err != nil {
+		return fmt.Errorf("unable to convert request body to []byte: %s", err)
+	}
+	if tc.response.body, err = convertBody(responseBody); err != nil {
+		return fmt.Errorf("unable to convert response body to []byte: %s", err)
+	}
+
+	if _, exists := s.tests[method]; !exists {
+		s.tests[method] = map[string][]*testCase{}
+	}
+	if _, exists := s.tests[method][uri]; !exists {
+		s.tests[method][uri] = []*testCase{}
+	}
+
+	t := new(testifyT)
+	for _, test := range s.tests[method][uri] {
+		header := assert.Equal(t, tc.request.headers, test.request.headers)
+		body := assert.Equal(t, tc.request.body, test.request.body)
+
+		if header && body {
+			return errors.New("test case already registered")
+		}
+	}
+
+	s.tests[method][uri] = append(s.tests[method][uri], tc)
+
+	return nil
+}
+
+func convertBody(body interface{}) ([]byte, error) {
+	switch b := body.(type) {
+	case []byte:
+		return b, nil
+	case string:
+		return []byte(b), nil
+	}
+
+	return json.Marshal(body)
+}

--- a/mockns1/testcase.go
+++ b/mockns1/testcase.go
@@ -36,7 +36,7 @@ func (s *Service) AddTestCase(
 	if !strings.HasPrefix(uri, "/v1/") {
 		uri = "/v1/" + uri
 	}
-	uri = strings.ReplaceAll(uri, "//", "/")
+	uri = strings.Replace(uri, "//", "/", -1)
 
 	tc := &testCase{
 		status: returnStatus,

--- a/mockns1/testcase_test.go
+++ b/mockns1/testcase_test.go
@@ -1,6 +1,8 @@
 package mockns1_test
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -9,11 +11,11 @@ import (
 )
 
 func TestTestCase(t *testing.T) {
-	t.Run("AddTestCase", func(t *testing.T) {
-		mock, _, err := mockns1.New(t)
-		require.Nil(t, err)
-		defer mock.Shutdown()
+	mock, _, err := mockns1.New(t)
+	require.Nil(t, err)
+	defer mock.Shutdown()
 
+	t.Run("AddTestCase", func(t *testing.T) {
 		t.Run("Error", func(t *testing.T) {
 			t.Run("Duplicate", func(t *testing.T) {
 				require.Nil(t, mock.AddTestCase(http.MethodGet, "test/header", http.StatusOK,
@@ -29,5 +31,25 @@ func TestTestCase(t *testing.T) {
 			require.Nil(t, mock.AddTestCase(http.MethodGet, "test/case", http.StatusOK,
 				nil, nil, "", ""))
 		})
+	})
+
+	t.Run("ClearTestCases", func(t *testing.T) {
+		require.Nil(t, mock.AddTestCase(http.MethodGet, "test/clear", http.StatusOK,
+			nil, nil, "", ""))
+
+		mw := &mockWriter{buf: bytes.NewBufferString("")}
+		req := &http.Request{
+			Method:     http.MethodGet,
+			RequestURI: "/v1/test/clear",
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			Header:     http.Header{},
+		}
+
+		mock.ServeHTTP(mw, req)
+		require.Equal(t, http.StatusOK, mw.status, mw.buf.String())
+
+		mock.ClearTestCases()
+		mock.ServeHTTP(mw, req)
+		require.Equal(t, http.StatusNotFound, mw.status, mw.buf.String())
 	})
 }

--- a/mockns1/testcase_test.go
+++ b/mockns1/testcase_test.go
@@ -1,0 +1,33 @@
+package mockns1_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ns1/ns1-go.v2/mockns1"
+)
+
+func TestTestCase(t *testing.T) {
+	t.Run("AddTestCase", func(t *testing.T) {
+		mock, _, err := mockns1.New(t)
+		require.Nil(t, err)
+		defer mock.Shutdown()
+
+		t.Run("Error", func(t *testing.T) {
+			t.Run("Duplicate", func(t *testing.T) {
+				require.Nil(t, mock.AddTestCase(http.MethodGet, "test/header", http.StatusOK,
+					nil, nil, "", ""))
+				err := mock.AddTestCase(http.MethodGet, "test/header", http.StatusOK,
+					nil, nil, "", "")
+				require.NotNil(t, err)
+				require.Equal(t, "test case already registered", err.Error())
+			})
+		})
+
+		t.Run("Success", func(t *testing.T) {
+			require.Nil(t, mock.AddTestCase(http.MethodGet, "test/case", http.StatusOK,
+				nil, nil, "", ""))
+		})
+	})
+}

--- a/mockns1/zone.go
+++ b/mockns1/zone.go
@@ -1,0 +1,67 @@
+package mockns1
+
+import (
+	"net/http"
+
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+// AddZoneListTestCase sets up a test case for the api.Client.Zones.List()
+// function
+func (s *Service) AddZoneListTestCase(
+	requestHeaders, responseHeaders http.Header,
+	response []*dns.Zone,
+) error {
+	return s.AddTestCase(
+		http.MethodGet, "/zones", http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddZoneGetTestCase sets up a test case for the api.Client.Zones.Get()
+// function
+func (s *Service) AddZoneGetTestCase(
+	name string,
+	requestHeaders, responseHeaders http.Header,
+	response *dns.Zone,
+) error {
+	return s.AddTestCase(
+		http.MethodGet, "/zones/"+name, http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddZoneCreateTestCase sets up a test case for the api.Client.Zones.Create()
+// function
+func (s *Service) AddZoneCreateTestCase(
+	requestHeaders, responseHeaders http.Header,
+	zone, response *dns.Zone,
+) error {
+	return s.AddTestCase(
+		http.MethodPut, "/zones/"+zone.Zone, http.StatusCreated, requestHeaders,
+		responseHeaders, zone, response,
+	)
+}
+
+// AddZoneUpdateTestCase sets up a test case for the api.Client.Zones.Update()
+// function
+func (s *Service) AddZoneUpdateTestCase(
+	requestHeaders, responseHeaders http.Header,
+	zone, response *dns.Zone,
+) error {
+	return s.AddTestCase(
+		http.MethodPost, "/zones/"+zone.Zone, http.StatusOK, requestHeaders,
+		responseHeaders, zone, response,
+	)
+}
+
+// AddZoneDeleteTestCase sets up a test case for the api.Client.Zones.Delete()
+// function
+func (s *Service) AddZoneDeleteTestCase(
+	name string, requestHeaders, responseHeaders http.Header,
+) error {
+	return s.AddTestCase(
+		http.MethodDelete, "/zones/"+name, http.StatusNoContent, requestHeaders,
+		responseHeaders, "", "",
+	)
+}

--- a/mockns1/zone_test.go
+++ b/mockns1/zone_test.go
@@ -1,0 +1,103 @@
+package mockns1_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ns1/ns1-go.v2/mockns1"
+	api "gopkg.in/ns1/ns1-go.v2/rest"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+func TestZone(t *testing.T) {
+	mock, doer, err := mockns1.New(t)
+	require.Nil(t, err)
+	defer mock.Shutdown()
+
+	client := api.NewClient(doer, api.SetEndpoint("https://"+mock.Address+"/v1/"))
+
+	t.Run("AddZoneListTestCase", func(t *testing.T) {
+		zones := []*dns.Zone{
+			{Zone: "a.list.zone"},
+			{Zone: "b.list.zone"},
+			{Zone: "c.list.zone"},
+			{Zone: "d.list.zone"},
+		}
+
+		require.Nil(t, mock.AddZoneListTestCase(nil, nil, zones))
+
+		resp, _, err := client.Zones.List()
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, len(zones), len(resp))
+
+		for i := range zones {
+			require.Equal(t, zones[i].Zone, resp[i].Zone, i)
+		}
+	})
+
+	t.Run("AddZoneGetTestCase", func(t *testing.T) {
+		zone := &dns.Zone{
+			Zone: "get.zone",
+			Records: []*dns.ZoneRecord{
+				{Domain: "a.get.zone"},
+				{Domain: "b.get.zone"},
+			},
+		}
+
+		require.Nil(t, mock.AddZoneGetTestCase(zone.Zone, nil, nil, zone))
+
+		resp, _, err := client.Zones.Get(zone.Zone)
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, zone.Zone, resp.Zone)
+		require.Equal(t, len(zone.Records), len(resp.Records))
+
+		for i := range zone.Records {
+			require.Equal(t, zone.Records[i].Domain, resp.Records[i].Domain, i)
+		}
+	})
+
+	t.Run("AddZoneCreateTestCase", func(t *testing.T) {
+		zone := &dns.Zone{
+			Zone: "create.zone",
+		}
+		var resp *dns.Zone
+		deepcopy(t, zone, &resp)
+
+		resp.TTL = 42
+
+		require.Nil(t, mock.AddZoneCreateTestCase(nil, nil, zone, resp))
+		require.Zero(t, zone.TTL)
+
+		_, err := client.Zones.Create(zone)
+		require.Nil(t, err)
+		require.Equal(t, zone.TTL, resp.TTL)
+	})
+
+	t.Run("AddZoneUpdateTestCase", func(t *testing.T) {
+		zone := &dns.Zone{
+			Zone: "update.zone",
+			TTL:  42,
+		}
+
+		require.Nil(t, mock.AddZoneUpdateTestCase(nil, nil, zone, zone))
+
+		_, err := client.Zones.Update(zone)
+		require.Nil(t, err)
+	})
+
+	t.Run("AddZoneDeleteTestCase", func(t *testing.T) {
+		require.Nil(t, mock.AddZoneDeleteTestCase("delete.zone", nil, nil))
+
+		_, err := client.Zones.Delete("delete.zone")
+		require.Nil(t, err)
+	})
+}
+
+func deepcopy(t *testing.T, source, target interface{}) {
+	data, err := json.Marshal(source)
+	require.Nil(t, err)
+	require.Nil(t, json.Unmarshal(data, target))
+}

--- a/rest/zone.go
+++ b/rest/zone.go
@@ -22,7 +22,7 @@ func (s *ZonesService) List() ([]*dns.Zone, *http.Response, error) {
 
 	zl := []*dns.Zone{}
 	var resp *http.Response
-	if s.client.FollowPagination == true {
+	if s.client.FollowPagination {
 		resp, err = s.client.DoWithPagination(req, &zl, s.nextZones)
 	} else {
 		resp, err = s.client.Do(req, &zl)
@@ -47,7 +47,7 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 
 	var z dns.Zone
 	var resp *http.Response
-	if s.client.FollowPagination == true {
+	if s.client.FollowPagination {
 		resp, err = s.client.DoWithPagination(req, &z, s.nextRecords)
 	} else {
 		resp, err = s.client.Do(req, &z)


### PR DESCRIPTION
Hello, I'm submitting a mock package that users can use to mock the NS1 API service for their own unit testing. This PR covers the basic functionality that can be used to emulate any API request/response, but I plan to add more helper functions (see `mockns1/zone.go`) in later PRs to further simplify usage. I just didn't to do too much right now (both to make your review easier and so I didn't spend a lot of time on it if you don't approve :wink: ).

- `mockns1`
  - Initial add of the mock service
  - Added helper functions to simplify testing `api.Client.Zones` calls.
- `rest`
  - Refactored `zone_test.go` tests
    - Made use of the `mockns1` service
    - Moved the tests to the `rest_test` package to ensure exported functionality is verified.
    - Refactored from individual test functions to using the `t.Run()` sub-testing pattern.
    - Utilized `testify/require` instead of `testify/assert` as it stops the (sub)test execution rather than allowing it to continue.
    - Added tests for `Create()`, `Update()`, and `Delete()`.
  - Removed superfluous `== true` comparisons
    - Maybe consider switching to [golangci-lint](https://github.com/golangci/golangci-lint) over `go vet` and `golint`?

From `mockns1/example_test.go`:

```go
// Setup the mock service
mock, doer, err := mockns1.New(t)
require.Nil(t, err)

defer mock.Shutdown()

// Create your NS1 client and configure it for the mock service
ns1 := api.NewClient(doer, api.SetAPIKey("apikey"))
ns1.Endpoint, _ = url.Parse("https://" + mock.Address + "/v1/")

// Add your test case (zone list in this example)
require.Nil(t, mock.AddTestCase(http.MethodGet, "zones", http.StatusOK, nil, nil, "",
	[]*dns.Zone{{Zone: "foo.bar"}}))

// Perform your tests
zones, _, err := ns1.Zones.List()
require.Nil(t, err)
require.Equal(t, 1, len(zones))
require.Equal(t, "foo.bar", zones[0].Zone)
```

```
$ make test
go fmt ./...
go vet ./...
golint ./...
go test ./...
?   	gopkg.in/ns1/ns1-go.v2	[no test files]
ok  	gopkg.in/ns1/ns1-go.v2/mockns1	(cached)
ok  	gopkg.in/ns1/ns1-go.v2/rest	(cached)
?   	gopkg.in/ns1/ns1-go.v2/rest/model	[no test files]
ok  	gopkg.in/ns1/ns1-go.v2/rest/model/account	(cached)
ok  	gopkg.in/ns1/ns1-go.v2/rest/model/data	(cached)
ok  	gopkg.in/ns1/ns1-go.v2/rest/model/dns	(cached)
?   	gopkg.in/ns1/ns1-go.v2/rest/model/filter	[no test files]
ok  	gopkg.in/ns1/ns1-go.v2/rest/model/monitor	(cached)
```