### PR TITLE
bump version to fix tagging issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.5.0 (Unreleased)
 
+## 2.4.1
+BUGFIX:
+* Fix incorrect tag
+
 ## 2.4.0
 FEATURES:
 * Exported mock API service - @iamgnat

--- a/rest/client.go
+++ b/rest/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	clientVersion = "2.4.0"
+	clientVersion = "2.4.1"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true


### PR DESCRIPTION
Need to release 2.4.1 to re-tag it, I think 2.4.0 was pointed to an older version of master