### PR TITLE
support for named zones/dns views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 2.5.0 (Unreleased)
+FEATURES:
+* Added support for named zones
 
 ## 2.4.2
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,87 @@ func main() {
 }
 ```
 
+DNS views and compatibility
+===========================
+
+DNS views is a means for NS1 to serve one set of data to one group of clients
+(e.g. internal employees), and different sets of data to other groups of
+clients (e.g. public internet). This has been largely exposed by allowing zones
+in the NS1 system to share the same FQDN, and allowing propagation to be
+controlled via ACLs and "views". For existing zones, and users that have no
+need for the added complexity of views, the default behavior is unchanged.
+However, it is important to understand that the requirement that an FQDN be
+unique within the network is removed in v3.x, and the ramifications of that.
+
+Views are available in API v3.x. For more information, see:
+https://help.ns1.com/hc/en-us/articles/360054071374
+
+COMPATIBILITY
+
+Since an FQDN can now appear in more than one "zone", it can no longer uniquely
+identify a zone. Instead, a user-supplied "name", unique within an account,
+is used to uniquely identify the zone.
+
+The zone name can be the same as its FQDN, existing zones transfer to the new
+schema this way. And if not using views, it does serve as a good identifier.
+However, if a second zone is created pointing to same FQDN, it cannot reuse
+the FQDN as an identifier, and queries for the zone FQDN (as an identfier)
+will return the first zone. The following example should help illustrate:
+
+In general, for API requests, the identifier for a zone will appear in the URL.
+They can also be passed or received as fields on an object. In the following
+request to a v2.x system, we use ZONE as an identifier in the URL, and may
+pass the `zone` field as an indicator of the FQDN for the zone.
+
+$ENDPOINT/v1/zones/example.com -d '{zone: example.com}'
+                   ^                ^
+                   L___ ZONE (id)   L____ ZONE (fqdn)
+
+Note also that it has been an ERROR if the values in the URL and `zone` field
+do not match, and the API would reject.
+
+Going forward, the unique identifier and FQDN of the zone are decoupled. The
+reference in the URL is user-assignable, and is passed and returned using the
+`name` field for zones (and the `zone_name` field for records). In the new
+paradigm, the previous call would look more like:
+
+$ENDPOINT/v1/zones/example.com -d '{zone: example.com, name: example.com}'
+                   ^                ^                  ^
+                   L___ NAME        L____ ZONE         L____ NAME
+
+For compatibility, if `name` isn't present, the API will use the FQDN, so the
+2.x call above should continue to work, and have the same result.
+
+However, in 3.x we are now allowed to make new zones with the same FQDN:
+
+$ENDPOINT/v1/zones/example-internal -d '{zone: example.com, name: example-internal}'
+                   ^                     ^                  ^
+                   L___ NAME             L____ ZONE         L____ NAME
+
+`example-internal` shares the FQDN with `example.com`. API calls using
+`example.com` as the identifier will uniquely identify the first zone, to
+address the second zone, `example-internal` must be used in the identifier
+
+So, you can continue to use the FQDN as an identifier - in fact, if you
+are not using "views", it is recommended that you do so, but other zones using
+the same FQDN will have to choose different names.
+
+Note also that both the example-internal and example.com "zones" can coexist.
+How they are propagated relies on how they are organized with regard to views,
+acls, and networks.
+
+SUMMARY OF CHANGES TO THE SDK FOR VIEWS
+
+For compatibility, we've left the `zone` variable alone in existing functions.
+When name and FQDN differ, and you are calling a func that takes `zone`, you
+want to pass the identifier, `name`. The only time you need to be sure to pass
+the zone's FQDN is on zone or record creation, where we need to know it.
+Otherwise, we're doing lookups, and the `name` is the unambigious field.
+
+For those using views, the NewNamedZone and NewNamedRecord funcs are provided
+to create zones and records. If not using views, you can opt to continue using
+the older functions.
+
 Contributing
 ============
 Pull Requests and issues are welcome. See the [NS1 Contribution Guidelines](https://github.com/ns1/community) for more information.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ENDPOINT/v1/zones/example-internal -d '{zone: example.com, name: example-intern
                    L___ NAME             L____ ZONE         L____ NAME
 
 `example-internal` shares the FQDN with `example.com`. API calls using
-`example.com` as the identifier will uniquely identify the first zone, to
+`example.com` as the identifier will uniquely identify the first zone. To
 address the second zone, `example-internal` must be used in the identifier
 
 So, you can continue to use the FQDN as an identifier - in fact, if you
@@ -128,7 +128,7 @@ For compatibility, we've left the `zone` variable alone in existing functions.
 When name and FQDN differ, and you are calling a func that takes `zone`, you
 want to pass the identifier, `name`. The only time you need to be sure to pass
 the zone's FQDN is on zone or record creation, where we need to know it.
-Otherwise, we're doing lookups, and the `name` is the unambigious field.
+Otherwise, we're doing lookups, and the `name` is the unambiguous field.
 
 For those using views, the NewNamedZone and NewNamedRecord funcs are provided
 to create zones and records. If not using views, you can opt to continue using

--- a/rest/model/data/meta.go
+++ b/rest/model/data/meta.go
@@ -129,7 +129,7 @@ type Meta struct {
 	// Values between 0 and 100 are recommended for simplicity's sake.
 	// float64 or FeedPtr.
 	Weight interface{} `json:"weight,omitempty"`
-	
+
 	// Indicates a cost.
 	// Filters that use costs normalize them.
 	// Any positive values are allowed.

--- a/rest/model/dns/example_test.go
+++ b/rest/model/dns/example_test.go
@@ -38,6 +38,7 @@ func ExampleZone_MakePrimary() {
 	// Output:
 	// {
 	//   "zone": "masterzone.example",
+	//   "name": "masterzone.example",
 	//   "primary": {
 	//     "enabled": true,
 	//     "secondaries": [
@@ -103,7 +104,7 @@ func ExampleRecord() {
 	fmt.Println(record.Regions["test"].Meta.Up)
 
 	// Output:
-	// a.test.com A
+	// [test.com] a.test.com A
 	// 300
 	// Primary answer:
 	// 1.1.1.1
@@ -135,7 +136,7 @@ func ExampleRecord_LinkTo() {
 	fmt.Println(linkedRecord.Meta)
 	fmt.Println(linkedRecord.Answers)
 	// Output:
-	// l.test.com A
+	// [test.com] l.test.com A
 	// <nil>
 	// []
 }

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -14,7 +14,8 @@ type Record struct {
 	Meta *data.Meta `json:"meta,omitempty"`
 
 	ID              string `json:"id,omitempty"`
-	Zone            string `json:"zone"`
+	ZoneName        string `json:"zone_name"` // Name of the zone (may == FQDN)
+	Zone            string `json:"zone"`      // FQDN of the zone
 	Domain          string `json:"domain"`
 	Type            string `json:"type"`
 	Link            string `json:"link,omitempty"`
@@ -30,7 +31,18 @@ type Record struct {
 }
 
 func (r Record) String() string {
+	if r.ZoneName != "" {
+		return fmt.Sprintf("[%s] %s %s", r.ZoneName, r.Domain, r.Type)
+	}
 	return fmt.Sprintf("%s %s", r.Domain, r.Type)
+}
+
+// GetZoneName returns the Name if present, otherwise FQDN is the Name
+func (r Record) GetZoneName() string {
+	if r.ZoneName == "" {
+		return r.Zone
+	}
+	return r.ZoneName
 }
 
 // NewRecord takes a zone, domain and record type t and creates a *Record with
@@ -40,19 +52,39 @@ func NewRecord(zone string, domain string, t string) *Record {
 		domain = fmt.Sprintf("%s.%s", domain, zone)
 	}
 	return &Record{
-		Meta:    &data.Meta{},
-		Zone:    zone,
-		Domain:  domain,
-		Type:    t,
-		Answers: []*Answer{},
-		Filters: []*filter.Filter{},
-		Regions: data.Regions{},
+		Meta:     &data.Meta{},
+		Zone:     zone,
+		ZoneName: zone,
+		Domain:   domain,
+		Type:     t,
+		Answers:  []*Answer{},
+		Filters:  []*filter.Filter{},
+		Regions:  data.Regions{},
+	}
+}
+
+// NewNamedRecord takes a zone name, zone FQDN, domain and record type t and
+// creates a *Record with ZoneName distinct from Zone
+func NewNamedRecord(zoneName string, zoneFQDN string, domain string, t string) *Record {
+	if !strings.HasSuffix(domain, zoneFQDN) {
+		domain = fmt.Sprintf("%s.%s", domain, zoneFQDN)
+	}
+	return &Record{
+		Meta:     &data.Meta{},
+		Zone:     zoneFQDN,
+		ZoneName: zoneName,
+		Domain:   domain,
+		Type:     t,
+		Answers:  []*Answer{},
+		Filters:  []*filter.Filter{},
+		Regions:  data.Regions{},
 	}
 }
 
 // LinkTo sets a Record Link to an FQDN.
 // to is the FQDN of the target record whose config should be used. Does
 // not have to be in the same zone.
+// Note: this may not be compatible with DNS views
 func (r *Record) LinkTo(to string) {
 	r.Meta = nil
 	r.Answers = []*Answer{}

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -16,7 +16,7 @@ var marshalRecordCases = []struct {
 		"marshalCAARecord",
 		NewRecord("example.com", "caa.example.com", "CAA"),
 		[]*Answer{NewCAAAnswer(0, "issue", "letsencrypt.org")},
-		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}],"filters":[]}`),
+		[]byte(`{"meta":{},"zone_name":"example.com","zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}],"filters":[]}`),
 	},
 	{
 		"marshalURLFWDRecord",
@@ -25,7 +25,7 @@ var marshalRecordCases = []struct {
 			NewURLFWDAnswer("/net", "https://example.net", 301, 1, 1),
 			NewURLFWDAnswer("/org", "https://example.org", 302, 2, 0),
 		},
-		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD","filters":[]}`),
+		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone_name":"example.com","zone":"example.com","domain":"fwd.example.com","type":"URLFWD","filters":[]}`),
 	},
 }
 

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -14,7 +14,10 @@ type Zone struct {
 	Pool         string   `json:"pool,omitempty"` // Deprecated
 
 	ID   string `json:"id,omitempty"`
-	Zone string `json:"zone,omitempty"`
+	Zone string `json:"zone,omitempty"` // FQDN
+	// Unique identifier for the zone within account. In most cases, it is best
+	// to also use the zone FQDN for this.
+	Name string `json:"name,omitempty"`
 
 	TTL        int    `json:"ttl,omitempty"`
 	NxTTL      int    `json:"nx_ttl,omitempty"`
@@ -41,10 +44,13 @@ type Zone struct {
 	// Whether or not DNSSEC is enabled on the zone. Note we use a pointer so
 	// leaving this unset will not change a previous setting.
 	DNSSEC *bool `json:"dnssec,omitempty"`
+
+	// Array of view names
+	Views []string `json:"views,omitempty"`
 }
 
 func (z Zone) String() string {
-	return z.Zone
+	return z.GetName()
 }
 
 // ZoneRecord wraps Zone's "records" attribute
@@ -110,9 +116,27 @@ type TSIG struct {
 // NewZone takes a zone domain name and creates a new zone.
 func NewZone(zone string) *Zone {
 	z := Zone{
+		Name: zone,
 		Zone: zone,
 	}
 	return &z
+}
+
+// NewNamedZone takes a zone name and FQDN and creates a new zone.
+func NewNamedZone(name string, zone string) *Zone {
+	z := Zone{
+		Zone: zone,
+		Name: name,
+	}
+	return &z
+}
+
+// GetName returns the Name, if present, other FQDN is the name
+func (z *Zone) GetName() string {
+	if z.Name != "" {
+		return z.Name
+	}
+	return z.Zone
 }
 
 // MakePrimary enables Primary, disables Secondary, and sets primary's

--- a/rest/record.go
+++ b/rest/record.go
@@ -42,7 +42,7 @@ func (s *RecordsService) Get(zone, domain, t string) (*dns.Record, *http.Respons
 // The given record must have at least one answer.
 // NS1 API docs: https://ns1.com/api/#record-put
 func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
-	path := fmt.Sprintf("zones/%s/%s/%s", r.Zone, r.Domain, r.Type)
+	path := fmt.Sprintf("zones/%s/%s/%s", r.GetZoneName(), r.Domain, r.Type)
 
 	req, err := s.client.NewRequest("PUT", path, &r)
 	if err != nil {
@@ -72,7 +72,7 @@ func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
 // Only the fields to be updated are required in the given record.
 // NS1 API docs: https://ns1.com/api/#record-post
 func (s *RecordsService) Update(r *dns.Record) (*http.Response, error) {
-	path := fmt.Sprintf("zones/%s/%s/%s", r.Zone, r.Domain, r.Type)
+	path := fmt.Sprintf("zones/%s/%s/%s", r.GetZoneName(), r.Domain, r.Type)
 
 	req, err := s.client.NewRequest("POST", path, &r)
 	if err != nil {

--- a/rest/zone.go
+++ b/rest/zone.go
@@ -69,7 +69,7 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#zones-put
 func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
-	path := fmt.Sprintf("zones/%s", z.Zone)
+	path := fmt.Sprintf("zones/%s", z.GetName())
 
 	req, err := s.client.NewRequest("PUT", path, &z)
 	if err != nil {
@@ -95,7 +95,7 @@ func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#zones-post
 func (s *ZonesService) Update(z *dns.Zone) (*http.Response, error) {
-	path := fmt.Sprintf("zones/%s", z.Zone)
+	path := fmt.Sprintf("zones/%s", z.GetName())
 
 	req, err := s.client.NewRequest("POST", path, &z)
 	if err != nil {


### PR DESCRIPTION
from a views POV:
  * where thing take a "zone" argument, this is used as the "name".
    I haven't renamed the variables, but maybe i should?
  * existing zone and record create funcs set both the FQDN and name
    to the passed "zone"
  * new zone and record create funcs added for passing both handle and name.
    you could also edit the object returned by the "old" function.
  * crud funcs that take a model use GetName/GetZoneName when building
    url
  * As noted, other funcs should all work as normal, with the caveat
    that if "name/zoneName" != FQDN, the name must be passed..

zone model gets:
  * Name attr
  * Views list attr
  * String method shows name, if present
  * GetName method (rather than try to keep the object sync'd)

record model gets:
  * Name attr
  * String method shows zoneName, if present
  * GetZoneName method (rather than try to keep the object sync'd)