### PR TITLE
Test against Go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.10.3
+- 1.15.x
 go_import_path: gopkg.in/ns1/ns1-go.v2
 script: script/test
 notifications:


### PR DESCRIPTION
Currently tests are failing because this library uses `testify` which no longer supports the version of Go tests are running as (Go 1.10). Bumping to latest should allow tests to run.