### PR TITLE
DNS tagging support

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -27,6 +27,16 @@ type Record struct {
 	Filters []*filter.Filter `json:"filters"`
 	// The records' regions.
 	Regions data.Regions `json:"regions,omitempty"`
+
+	// Contains the key/value tag information associated to the record
+	Tags map[string]string `json:"tags,omitempty"`
+
+	// List of tag key names that should not inherit from the parent zone
+	BlockedTags []string `json:"blocked_tags,omitempty"`
+
+	// List of tag key namess set directly on this record. Any other Tag entries
+	// are inherited from the parent zone
+	LocalTags []string `json:"local_tags,omitempty"`
 }
 
 func (r Record) String() string {
@@ -40,13 +50,16 @@ func NewRecord(zone string, domain string, t string) *Record {
 		domain = fmt.Sprintf("%s.%s", domain, zone)
 	}
 	return &Record{
-		Meta:    &data.Meta{},
-		Zone:    zone,
-		Domain:  domain,
-		Type:    t,
-		Answers: []*Answer{},
-		Filters: []*filter.Filter{},
-		Regions: data.Regions{},
+		Meta:        &data.Meta{},
+		Zone:        zone,
+		Domain:      domain,
+		Type:        t,
+		Answers:     []*Answer{},
+		Filters:     []*filter.Filter{},
+		Regions:     data.Regions{},
+		Tags:        map[string]string{},
+		BlockedTags: []string{},
+		LocalTags:   []string{},
 	}
 }
 

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -29,14 +29,13 @@ type Record struct {
 	Regions data.Regions `json:"regions,omitempty"`
 
 	// Contains the key/value tag information associated to the record
-	Tags map[string]string `json:"tags,omitempty"`
+	Tags map[string]string `json:"tags,omitempty"` // Only relevant for DDI
 
 	// List of tag key names that should not inherit from the parent zone
-	BlockedTags []string `json:"blocked_tags,omitempty"`
+	BlockedTags []string `json:"blocked_tags,omitempty"` //Only relevant for DDI
 
-	// List of tag key namess set directly on this record. Any other Tag entries
-	// are inherited from the parent zone
-	LocalTags []string `json:"local_tags,omitempty"`
+	// Read-only fields
+	LocalTags []string `json:"local_tags,omitempty"` // Only relevant for DDI
 }
 
 func (r Record) String() string {
@@ -59,7 +58,6 @@ func NewRecord(zone string, domain string, t string) *Record {
 		Regions:     data.Regions{},
 		Tags:        map[string]string{},
 		BlockedTags: []string{},
-		LocalTags:   []string{},
 	}
 }
 

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -49,15 +49,13 @@ func NewRecord(zone string, domain string, t string) *Record {
 		domain = fmt.Sprintf("%s.%s", domain, zone)
 	}
 	return &Record{
-		Meta:        &data.Meta{},
-		Zone:        zone,
-		Domain:      domain,
-		Type:        t,
-		Answers:     []*Answer{},
-		Filters:     []*filter.Filter{},
-		Regions:     data.Regions{},
-		Tags:        map[string]string{},
-		BlockedTags: []string{},
+		Meta:    &data.Meta{},
+		Zone:    zone,
+		Domain:  domain,
+		Type:    t,
+		Answers: []*Answer{},
+		Filters: []*filter.Filter{},
+		Regions: data.Regions{},
 	}
 }
 

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -1,7 +1,10 @@
 package dns
 
-import "encoding/json"
-import "gopkg.in/ns1/ns1-go.v2/rest/model/data"
+import (
+	"encoding/json"
+
+	"gopkg.in/ns1/ns1-go.v2/rest/model/data"
+)
 
 // Zone wraps an NS1 /zone resource
 type Zone struct {
@@ -41,6 +44,16 @@ type Zone struct {
 	// Whether or not DNSSEC is enabled on the zone. Note we use a pointer so
 	// leaving this unset will not change a previous setting.
 	DNSSEC *bool `json:"dnssec,omitempty"`
+
+	// Contains the key/value tag information associated to the zone
+	Tags map[string]string `json:"tags,omitempty"`
+
+	// List of tag key names that should not inherit from the parent object
+	BlockedTags []string `json:"blocked_tags,omitempty"`
+
+	// List of tag key namess set directly on this zone. Any other Tag entries
+	// are inherited from a higher level
+	LocalTags []string `json:"local_tags,omitempty"`
 }
 
 func (z Zone) String() string {
@@ -56,6 +69,16 @@ type ZoneRecord struct {
 	Tier     json.Number `json:"tier,omitempty"`
 	TTL      int         `json:"ttl,omitempty"`
 	Type     string      `json:"type,omitempty"`
+
+	// Contains the key/value tag information associated to the record
+	Tags map[string]string `json:"tags,omitempty"`
+
+	// List of tag key names that should not inherit from the parent zone
+	BlockedTags []string `json:"blocked_tags,omitempty"`
+
+	// List of tag key namess set directly on this record. Any other Tag entries
+	// are inherited from the zone
+	LocalTags []string `json:"local_tags,omitempty"`
 }
 
 // ZonePrimary wraps a Zone's "primary" attribute
@@ -110,7 +133,10 @@ type TSIG struct {
 // NewZone takes a zone domain name and creates a new zone.
 func NewZone(zone string) *Zone {
 	z := Zone{
-		Zone: zone,
+		Zone:        zone,
+		Tags:        map[string]string{},
+		BlockedTags: []string{},
+		LocalTags:   []string{},
 	}
 	return &z
 }

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -14,7 +14,8 @@ type Zone struct {
 	// Read-only fields
 	DNSServers   []string `json:"dns_servers,omitempty"`
 	NetworkPools []string `json:"network_pools,omitempty"`
-	Pool         string   `json:"pool,omitempty"` // Deprecated
+	Pool         string   `json:"pool,omitempty"`       // Deprecated
+	LocalTags    []string `json:"local_tags,omitempty"` // Only relevant for DDI
 
 	ID   string `json:"id,omitempty"`
 	Zone string `json:"zone,omitempty"`
@@ -46,14 +47,7 @@ type Zone struct {
 	DNSSEC *bool `json:"dnssec,omitempty"`
 
 	// Contains the key/value tag information associated to the zone
-	Tags map[string]string `json:"tags,omitempty"`
-
-	// List of tag key names that should not inherit from the parent object
-	BlockedTags []string `json:"blocked_tags,omitempty"`
-
-	// List of tag key namess set directly on this zone. Any other Tag entries
-	// are inherited from a higher level
-	LocalTags []string `json:"local_tags,omitempty"`
+	Tags map[string]string `json:"tags,omitempty"` // Only relevant for DDI
 }
 
 func (z Zone) String() string {
@@ -133,10 +127,8 @@ type TSIG struct {
 // NewZone takes a zone domain name and creates a new zone.
 func NewZone(zone string) *Zone {
 	z := Zone{
-		Zone:        zone,
-		Tags:        map[string]string{},
-		BlockedTags: []string{},
-		LocalTags:   []string{},
+		Zone: zone,
+		Tags: map[string]string{},
 	}
 	return &z
 }

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -128,7 +128,6 @@ type TSIG struct {
 func NewZone(zone string) *Zone {
 	z := Zone{
 		Zone: zone,
-		Tags: map[string]string{},
 	}
 	return &z
 }

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -64,15 +64,11 @@ type ZoneRecord struct {
 	TTL      int         `json:"ttl,omitempty"`
 	Type     string      `json:"type,omitempty"`
 
-	// Contains the key/value tag information associated to the record
-	Tags map[string]string `json:"tags,omitempty"`
+	// Contains the key/value tag information associated to the zone
+	Tags map[string]string `json:"tags,omitempty"` // Only relevant for DDI
 
-	// List of tag key names that should not inherit from the parent zone
-	BlockedTags []string `json:"blocked_tags,omitempty"`
-
-	// List of tag key namess set directly on this record. Any other Tag entries
-	// are inherited from the zone
-	LocalTags []string `json:"local_tags,omitempty"`
+	// Read-only fields
+	LocalTags []string `json:"local_tags,omitempty"` // Only relevant for DDI
 }
 
 // ZonePrimary wraps a Zone's "primary" attribute


### PR DESCRIPTION
Adding `Tags`, `BlockedTags`, and `LocalTags` fields to `Zone` and `Record` DNS objects to support new functionality in DDI 3.2.3