### PR TITLE
PERSONA-180 run rate limit when there is a response

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -164,16 +164,13 @@ func SetDDIAPI() func(*Client) {
 // non-2XX response.
 func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	resp, err := c.httpClient.Do(req)
-
-	if resp != nil {
-		rl := parseRate(resp)
-		c.RateLimitFunc(rl)
-	}
-
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	rl := parseRate(resp)
+	c.RateLimitFunc(rl)
 
 	err = CheckResponse(resp)
 	if err != nil {

--- a/rest/client.go
+++ b/rest/client.go
@@ -164,6 +164,12 @@ func SetDDIAPI() func(*Client) {
 // non-2XX response.
 func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	resp, err := c.httpClient.Do(req)
+
+	if resp != nil {
+		rl := parseRate(resp)
+		c.RateLimitFunc(rl)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -173,9 +179,6 @@ func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 	if err != nil {
 		return resp, err
 	}
-
-	rl := parseRate(resp)
-	c.RateLimitFunc(rl)
 
 	if v != nil {
 		// Try to unmarshal body into given type using streaming decoder.

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -108,16 +108,13 @@ func TestClient_DoWithHTTPClientErrorRateLimit(t *testing.T) {
 		Header:     headerResponse,
 		StatusCode: 400,
 	}
-	mockError := errors.New("Some Error")
-	httpClient.On("Do", req).Return(&mockResp, mockError)
+	httpClient.On("Do", req).Return(&mockResp, nil)
 
-	resp, err := client.Do(req, "")
+	client.Do(req, "")
 
 	httpClient.AssertExpectations(t)
 
-	assert.Nil(t, resp)
 	assert.NotNil(t, rateLimit)
-	assert.Equal(t, mockError, err)
 }
 
 func TestClient_DoWithNon2XXResponse(t *testing.T) {


### PR DESCRIPTION
When an error occurs the client will not run the rate limit, which causes too many requests to be fired and then will hit the endpoints rate limit. So to avoid this, the rate limit function will be run when there is a response from the client payload. This was noticed when running terraform provider with invalid fields, which caused 400 errors