### PR TITLE
More verbose error output when encoutering a JSON decoding error.

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -179,8 +180,12 @@ func (c Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 
 	if v != nil {
 		// Try to unmarshal body into given type using streaming decoder.
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
-			return nil, err
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error reading response body: %w", err)
+		}
+		if err := json.NewDecoder(strings.NewReader(string(body))).Decode(&v); err != nil {
+			return nil, fmt.Errorf("error decoding json response body. error: %w \nBody was: %s\nheaders were %+v", err, string(body), resp.Header)
 		}
 	}
 

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -155,7 +155,7 @@ func TestClient_DoWithNonJSONResponse(t *testing.T) {
 	httpClient.AssertExpectations(t)
 
 	assert.Nil(t, resp)
-	assert.IsType(t, &json.SyntaxError{}, err)
+	assert.IsType(t, &json.SyntaxError{}, errors.Unwrap(err))
 }
 
 func TestClient_DoWithPagination(t *testing.T) {


### PR DESCRIPTION
Getting more information about what was actually sent to the client would be vital for understanding the fault itself in the event of a JSON decoding error.

This returns output explaining the response headers and response body of what was actually returned given an API call.