### PR TITLE
Add created/updated time to Record model

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -36,6 +36,8 @@ type Record struct {
 
 	// Read-only fields
 	LocalTags []string `json:"local_tags,omitempty"` // Only relevant for DDI
+	CreatedAt int      `json:"created_at"`
+	UpdatedAt int      `json:"updated_at"`
 }
 
 func (r Record) String() string {


### PR DESCRIPTION
The API returns  `updated_at` and `created_at` fields, that are not used in the Record struct.
I have a usecase, where I need this data.