### PR TITLE
Update zone.go

### DIFF
--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -20,13 +20,14 @@ type Zone struct {
 	ID   string `json:"id,omitempty"`
 	Zone string `json:"zone,omitempty"`
 
-	TTL        int    `json:"ttl,omitempty"`
-	NxTTL      int    `json:"nx_ttl,omitempty"`
-	Retry      int    `json:"retry,omitempty"`
-	Serial     int    `json:"serial,omitempty"`
-	Refresh    int    `json:"refresh,omitempty"`
-	Expiry     int    `json:"expiry,omitempty"`
-	Hostmaster string `json:"hostmaster,omitempty"`
+	TTL           int    `json:"ttl,omitempty"`
+	NxTTL         int    `json:"nx_ttl,omitempty"`
+	Retry         int    `json:"retry,omitempty"`
+	Serial        int    `json:"serial,omitempty"`
+	Refresh       int    `json:"refresh,omitempty"`
+	Expiry        int    `json:"expiry,omitempty"`
+	Hostmaster    string `json:"hostmaster,omitempty"`
+	PrimaryMaster string `json:"primary_master,omitempty"`
 
 	// If this is a linked zone, Link points to an existing standard zone,
 	// reusing its configuration and records. Link is a zones' domain name.


### PR DESCRIPTION
Add forgotten field "primary_master", the Primary master name server for the zone in the Start of Authority record.