### PR TITLE
TEG-226/changed suffix check in NewRecord method to be case insenstive

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -45,7 +45,7 @@ func (r Record) String() string {
 // NewRecord takes a zone, domain and record type t and creates a *Record with
 // UseClientSubnet: true & empty Answers.
 func NewRecord(zone string, domain string, t string) *Record {
-	if !strings.HasSuffix(domain, zone) {
+	if !strings.HasSuffix(strings.ToLower(domain), strings.ToLower(zone)) {
 		domain = fmt.Sprintf("%s.%s", domain, zone)
 	}
 	return &Record{

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var marshalRecordCases = []struct {
@@ -42,6 +44,59 @@ func TestMarshalRecords(t *testing.T) {
 			if bytes.Compare(result, tt.out) != 0 {
 				t.Errorf("got %q, want %q", result, tt.out)
 			}
+		})
+	}
+}
+
+func TestNewRecord(t *testing.T) {
+	var CapitalLettersCases = []struct {
+		name           string
+		domain         string
+		zone           string
+		ExpectedDomain string
+		ExpectedZone   string
+	}{
+		{
+			"no cap letters",
+			"testcase1.case",
+			"testcase1.case",
+			"testcase1.case",
+			"testcase1.case",
+		},
+		{
+			"domain as title",
+			"Testcase2.case",
+			"testcase2.case",
+			"Testcase2.case",
+			"testcase2.case",
+		},
+		{
+			"zone with cap letters",
+			"testcase3.case",
+			"TeStCase3.case",
+			"testcase3.case",
+			"TeStCase3.case",
+		},
+		{
+			"Domain no cap letters without zone",
+			"test",
+			"testcase4.case",
+			"test.testcase4.case",
+			"testcase4.case",
+		},
+		{
+			"Domain with cap letters without zone",
+			"TEST",
+			"testcase4.case",
+			"TEST.testcase4.case",
+			"testcase4.case",
+		},
+	}
+	for _, tt := range CapitalLettersCases {
+		t.Run(tt.name, func(t *testing.T) {
+			record := NewRecord(tt.zone, tt.domain, "A")
+			assert.Equal(t, tt.ExpectedDomain, record.Domain)
+			assert.Equal(t, tt.ExpectedZone, record.Zone)
 		})
 	}
 }


### PR DESCRIPTION
Change suffix check to avoid duplicate domain when trying to create at root level. Ex: NewRecord("test.net", "Test.net", "A") would result in a Record of domain="Test.net.test.net" 
Created tests