### PR TITLE
rest/zone: fix zone exists error catching

### DIFF
--- a/rest/zone.go
+++ b/rest/zone.go
@@ -81,7 +81,7 @@ func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
 	if err != nil {
 		switch err.(type) {
 		case *Error:
-			if err.(*Error).Message == "zone already exists" {
+			if err.(*Error).Message == "invalid: FQDN already exists in the view" {
 				return resp, ErrZoneExists
 			}
 		}

--- a/rest/zone.go
+++ b/rest/zone.go
@@ -81,6 +81,9 @@ func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
 	if err != nil {
 		switch err.(type) {
 		case *Error:
+			if err.(*Error).Message == "zone already exists" {
+				return resp, ErrZoneExists
+			}
 			if err.(*Error).Message == "invalid: FQDN already exists in the view" {
 				return resp, ErrZoneExists
 			}

--- a/rest/zone_test.go
+++ b/rest/zone_test.go
@@ -195,7 +195,7 @@ func TestZone(t *testing.T) {
 
 			require.Nil(t, mock.AddTestCase(
 				http.MethodPut, "/zones/create.zone", http.StatusNotFound,
-				nil, nil, zone, `{"message": "zone already exists"}`,
+				nil, nil, zone, `{"message":"invalid: FQDN already exists in the view"}`,
 			))
 
 			_, err := client.Zones.Create(zone)


### PR DESCRIPTION
NS1 api returns "invalid: FQDN already exists in the view" instead
of "zone already exists" nowadays.

Let's catch this new error in our zone handling code.
