### PR TITLE
enable empty rules list

### DIFF
--- a/rest/model/monitor/job.go
+++ b/rest/model/monitor/job.go
@@ -24,7 +24,7 @@ type Job struct {
 	Status map[string]*Status `json:"status,omitempty"`
 
 	// Rules for determining failure conditions.
-	Rules []*Rule `json:"rules,omitempty"`
+	Rules []*Rule `json:"rules"`
 
 	// List of regions in which to run the monitor.
 	// eg, ["dal", "sin", "sjc", "lga", "ams"]


### PR DESCRIPTION
* Enable empty rules list so that Terraform provider or other clients can delete monitoring job rules when desired