### PR TITLE
don't trust received rate-limit headers

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -22,6 +22,8 @@ const (
 	headerRateLimit     = "X-Ratelimit-Limit"
 	headerRateRemaining = "X-Ratelimit-Remaining"
 	headerRatePeriod    = "X-Ratelimit-Period"
+
+	defaultRateLimitWaitTime = time.Millisecond * 100
 )
 
 // Doer is a single method interface that allows a user to extend/augment an http.Client instance.
@@ -309,6 +311,10 @@ func (rl RateLimit) PercentageLeft() int {
 
 // WaitTime returns the time.Duration ratio of Period to Limit
 func (rl RateLimit) WaitTime() time.Duration {
+	if rl.Limit == 0 || rl.Period == 0 {
+		// rate-limit headers missing or corrupt, punt
+		return defaultRateLimitWaitTime
+	}
 	return (time.Second * time.Duration(rl.Period)) / time.Duration(rl.Limit)
 }
 

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -15,6 +15,15 @@ import (
 
 func TestClient_RateLimit(t *testing.T) {
 	r := RateLimit{
+		Limit:     0,
+		Remaining: 0,
+		Period:    0,
+	}
+	if r.WaitTime() != defaultRateLimitWaitTime {
+		t.Errorf("WaitTime({limit=0}) result: got %v, wanted %v", r.WaitTime(), defaultRateLimitWaitTime)
+	}
+
+	r = RateLimit{
 		Limit:     10,
 		Remaining: 10,
 		Period:    10,


### PR DESCRIPTION
If the rate-limit header values in the API response are missing or corrupt, provide a default value of 100 ms. This will lead to a sleep of 100 ms times the "parallelism" user-settable value. For more details see the [NS1 Terraform provider documentation](https://registry.terraform.io/providers/ns1-terraform/ns1/latest/docs#rate_limit_parallelism).