### PR TITLE
release 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.2 (December 13, 2022)
+BUG FIXES:
+
+* When an HTTP error response with a non-JSON body is received, use the body as the error message (instead of a message about being unable to parse JSON).
+
+
 ## 2.7.1 (December 5, 2022)
 BUG FIXES:
 

--- a/rest/client.go
+++ b/rest/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	clientVersion = "2.7.1"
+	clientVersion = "2.7.2"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true


### PR DESCRIPTION
## 2.7.2 (December 13, 2022)
BUG FIXES:

* When an HTTP error response with a non-JSON body is received, use the body as the error message (instead of a message about being unable to parse JSON).
