### PR TITLE
Add "WithContext" methods

### DIFF
--- a/rest/account_apikey.go
+++ b/rest/account_apikey.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type APIKeysService service
 //
 // NS1 API docs: https://ns1.com/api/#apikeys-get
 func (s *APIKeysService) List() ([]*account.APIKey, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but accepts a context.
+func (s *APIKeysService) ListWithContext(ctx context.Context) ([]*account.APIKey, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "account/apikeys", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	kl := []*account.APIKey{}
 	resp, err := s.client.Do(req, &kl)
@@ -34,12 +41,18 @@ func (s *APIKeysService) List() ([]*account.APIKey, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#apikeys-id-get
 func (s *APIKeysService) Get(keyID string) (*account.APIKey, *http.Response, error) {
+	return s.GetWithContext(context.Background(), keyID)
+}
+
+// GetWithContext is the same as Get, but accepts a context.
+func (s *APIKeysService) GetWithContext(ctx context.Context, keyID string) (*account.APIKey, *http.Response, error) {
 	path := fmt.Sprintf("account/apikeys/%s", keyID)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var a account.APIKey
 	resp, err := s.client.Do(req, &a)
@@ -61,6 +74,11 @@ func (s *APIKeysService) Get(keyID string) (*account.APIKey, *http.Response, err
 //
 // NS1 API docs: https://ns1.com/api/#apikeys-put
 func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), a)
+}
+
+// CreateWithContext is the same as Create, but accepts a context.
+func (s *APIKeysService) CreateWithContext(ctx context.Context, a *account.APIKey) (*http.Response, error) {
 	var (
 		req *http.Request
 		err error
@@ -79,6 +97,7 @@ func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
 			return nil, err
 		}
 	}
+	req = req.WithContext(ctx)
 
 	// Update account fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &a)
@@ -99,6 +118,11 @@ func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#apikeys-id-post
 func (s *APIKeysService) Update(a *account.APIKey) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), a)
+}
+
+// UpdateWithContext is the same as Update, but accepts a context.
+func (s *APIKeysService) UpdateWithContext(ctx context.Context, a *account.APIKey) (*http.Response, error) {
 	path := fmt.Sprintf("account/apikeys/%s", a.ID)
 
 	var (
@@ -119,6 +143,7 @@ func (s *APIKeysService) Update(a *account.APIKey) (*http.Response, error) {
 			return nil, err
 		}
 	}
+	req = req.WithContext(ctx)
 
 	// Update apikey fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &a)
@@ -139,12 +164,18 @@ func (s *APIKeysService) Update(a *account.APIKey) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#apikeys-id-delete
 func (s *APIKeysService) Delete(keyID string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), keyID)
+}
+
+// DeleteWithContext is the same as Update, but accepts a context.
+func (s *APIKeysService) DeleteWithContext(ctx context.Context, keyID string) (*http.Response, error) {
 	path := fmt.Sprintf("account/apikeys/%s", keyID)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/account_setting.go
+++ b/rest/account_setting.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"net/http"
 
 	"gopkg.in/ns1/ns1-go.v2/rest/model/account"
@@ -13,10 +14,16 @@ type SettingsService service
 //
 // NS1 API docs: https://ns1.com/api/#settings-get
 func (s *SettingsService) Get() (*account.Setting, *http.Response, error) {
+	return s.GetWithContext(context.Background())
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *SettingsService) GetWithContext(ctx context.Context) (*account.Setting, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "account/settings", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var us account.Setting
 	resp, err := s.client.Do(req, &us)
@@ -31,10 +38,16 @@ func (s *SettingsService) Get() (*account.Setting, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#settings-post
 func (s *SettingsService) Update(us *account.Setting) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), us)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *SettingsService) UpdateWithContext(ctx context.Context, us *account.Setting) (*http.Response, error) {
 	req, err := s.client.NewRequest("POST", "account/settings", &us)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update usagewarnings fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &us)

--- a/rest/account_team.go
+++ b/rest/account_team.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type TeamsService service
 //
 // NS1 API docs: https://ns1.com/api/#teams-get
 func (s *TeamsService) List() ([]*account.Team, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *TeamsService) ListWithContext(ctx context.Context) ([]*account.Team, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "account/teams", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	tl := []*account.Team{}
 	resp, err := s.client.Do(req, &tl)
@@ -33,12 +40,18 @@ func (s *TeamsService) List() ([]*account.Team, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#teams-id-get
 func (s *TeamsService) Get(id string) (*account.Team, *http.Response, error) {
+	return s.GetWithContext(context.Background(), id)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *TeamsService) GetWithContext(ctx context.Context, id string) (*account.Team, *http.Response, error) {
 	path := fmt.Sprintf("account/teams/%s", id)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var t account.Team
 	resp, err := s.client.Do(req, &t)
@@ -59,6 +72,11 @@ func (s *TeamsService) Get(id string) (*account.Team, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#teams-put
 func (s *TeamsService) Create(t *account.Team) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), t)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *TeamsService) CreateWithContext(ctx context.Context, t *account.Team) (*http.Response, error) {
 	var (
 		req *http.Request
 		err error
@@ -77,6 +95,7 @@ func (s *TeamsService) Create(t *account.Team) (*http.Response, error) {
 			return nil, err
 		}
 	}
+	req = req.WithContext(ctx)
 
 	// Update team fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &t)
@@ -97,6 +116,11 @@ func (s *TeamsService) Create(t *account.Team) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#teams-id-post
 func (s *TeamsService) Update(t *account.Team) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), t)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *TeamsService) UpdateWithContext(ctx context.Context, t *account.Team) (*http.Response, error) {
 	path := fmt.Sprintf("account/teams/%s", t.ID)
 
 	var (
@@ -117,6 +141,7 @@ func (s *TeamsService) Update(t *account.Team) (*http.Response, error) {
 			return nil, err
 		}
 	}
+	req = req.WithContext(ctx)
 
 	// Update team fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &t)
@@ -137,12 +162,18 @@ func (s *TeamsService) Update(t *account.Team) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#teams-id-delete
 func (s *TeamsService) Delete(id string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), id)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *TeamsService) DeleteWithContext(ctx context.Context, id string) (*http.Response, error) {
 	path := fmt.Sprintf("account/teams/%s", id)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/account_user.go
+++ b/rest/account_user.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type UsersService service
 //
 // NS1 API docs: https://ns1.com/api/#users-get
 func (s *UsersService) List() ([]*account.User, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *UsersService) ListWithContext(ctx context.Context) ([]*account.User, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "account/users", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	ul := []*account.User{}
 	resp, err := s.client.Do(req, &ul)
@@ -33,12 +40,18 @@ func (s *UsersService) List() ([]*account.User, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#users-user-get
 func (s *UsersService) Get(username string) (*account.User, *http.Response, error) {
+	return s.GetWithContext(context.Background(), username)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *UsersService) GetWithContext(ctx context.Context, username string) (*account.User, *http.Response, error) {
 	path := fmt.Sprintf("account/users/%s", username)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var u account.User
 	resp, err := s.client.Do(req, &u)
@@ -59,6 +72,11 @@ func (s *UsersService) Get(username string) (*account.User, *http.Response, erro
 //
 // NS1 API docs: https://ns1.com/api/#users-put
 func (s *UsersService) Create(u *account.User) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), u)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *UsersService) CreateWithContext(ctx context.Context, u *account.User) (*http.Response, error) {
 	var (
 		req *http.Request
 		err error
@@ -77,6 +95,7 @@ func (s *UsersService) Create(u *account.User) (*http.Response, error) {
 			return nil, err
 		}
 	}
+	req = req.WithContext(ctx)
 
 	// Update user fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &u)
@@ -97,6 +116,11 @@ func (s *UsersService) Create(u *account.User) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#users-user-post
 func (s *UsersService) Update(u *account.User) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), u)
+}
+
+// UpdateWithContext is the same as Update, but takes a context
+func (s *UsersService) UpdateWithContext(ctx context.Context, u *account.User) (*http.Response, error) {
 	path := fmt.Sprintf("account/users/%s", u.Username)
 
 	var (
@@ -117,6 +141,7 @@ func (s *UsersService) Update(u *account.User) (*http.Response, error) {
 			return nil, err
 		}
 	}
+	req = req.WithContext(ctx)
 
 	// Update user fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &u)
@@ -137,12 +162,18 @@ func (s *UsersService) Update(u *account.User) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#users-user-delete
 func (s *UsersService) Delete(username string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), username)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *UsersService) DeleteWithContext(ctx context.Context, username string) (*http.Response, error) {
 	path := fmt.Sprintf("account/users/%s", username)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/account_warning.go
+++ b/rest/account_warning.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"net/http"
 
 	"gopkg.in/ns1/ns1-go.v2/rest/model/account"
@@ -14,10 +15,16 @@ type WarningsService service
 //
 // NS1 API docs: https://ns1.com/api/#usagewarnings-get
 func (s *WarningsService) Get() (*account.UsageWarning, *http.Response, error) {
+	return s.GetWithContext(context.Background())
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *WarningsService) GetWithContext(ctx context.Context) (*account.UsageWarning, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "account/usagewarnings", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var uw account.UsageWarning
 	resp, err := s.client.Do(req, &uw)
@@ -32,10 +39,16 @@ func (s *WarningsService) Get() (*account.UsageWarning, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#usagewarnings-post
 func (s *WarningsService) Update(uw *account.UsageWarning) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), uw)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *WarningsService) UpdateWithContext(ctx context.Context, uw *account.UsageWarning) (*http.Response, error) {
 	req, err := s.client.NewRequest("POST", "account/usagewarnings", &uw)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update usagewarnings fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &uw)

--- a/rest/application.go
+++ b/rest/application.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type ApplicationsService service
 //
 // NS1 API docs: https://ns1.com/api#get-list-pulsar-applications
 func (s *ApplicationsService) List() ([]*pulsar.Application, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *ApplicationsService) ListWithContext(ctx context.Context) ([]*pulsar.Application, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "pulsar/apps", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var al []*pulsar.Application
 	resp, err := s.client.Do(req, &al)
@@ -33,12 +40,18 @@ func (s *ApplicationsService) List() ([]*pulsar.Application, *http.Response, err
 //
 // NS1 API docs: https://ns1.com/api#get-list-pulsar-applications
 func (s *ApplicationsService) Get(id string) (*pulsar.Application, *http.Response, error) {
+	return s.GetWithContext(context.Background(), id)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *ApplicationsService) GetWithContext(ctx context.Context, id string) (*pulsar.Application, *http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s", id)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var a pulsar.Application
 	resp, err := s.client.Do(req, &a)
@@ -60,10 +73,16 @@ func (s *ApplicationsService) Get(id string) (*pulsar.Application, *http.Respons
 // The given application must have at least the name
 // NS1 API docs: https://ns1.com/api#put-create-a-pulsar-application
 func (s *ApplicationsService) Create(a *pulsar.Application) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), a)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *ApplicationsService) CreateWithContext(ctx context.Context, a *pulsar.Application) (*http.Response, error) {
 	req, err := s.client.NewRequest("PUT", "pulsar/apps", a)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 	resp, err := s.client.Do(req, a)
 	return resp, err
 }
@@ -72,12 +91,18 @@ func (s *ApplicationsService) Create(a *pulsar.Application) (*http.Response, err
 //
 // NS1 API docs: https://ns1.com/api#post-modify-an-application
 func (s *ApplicationsService) Update(a *pulsar.Application) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), a)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *ApplicationsService) UpdateWithContext(ctx context.Context, a *pulsar.Application) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s", a.ID)
 
 	req, err := s.client.NewRequest("POST", path, &a)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, &a)
 	if err != nil {
@@ -97,12 +122,18 @@ func (s *ApplicationsService) Update(a *pulsar.Application) (*http.Response, err
 //
 // NS1 API docs: https://ns1.com/api#delete-delete-a-pulsar-application
 func (s *ApplicationsService) Delete(id string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), id)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *ApplicationsService) DeleteWithContext(ctx context.Context, id string) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s", id)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/data_feed.go
+++ b/rest/data_feed.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -14,12 +15,18 @@ type DataFeedsService service
 //
 // NS1 API docs: https://ns1.com/api/#feeds-get
 func (s *DataFeedsService) List(sourceID string) ([]*data.Feed, *http.Response, error) {
+	return s.ListWithContext(context.Background(), sourceID)
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *DataFeedsService) ListWithContext(ctx context.Context, sourceID string) ([]*data.Feed, *http.Response, error) {
 	path := fmt.Sprintf("data/feeds/%s", sourceID)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	dfl := []*data.Feed{}
 	resp, err := s.client.Do(req, &dfl)
@@ -34,12 +41,18 @@ func (s *DataFeedsService) List(sourceID string) ([]*data.Feed, *http.Response, 
 //
 // NS1 API docs: https://ns1.com/api/#feeds-feed-get
 func (s *DataFeedsService) Get(sourceID string, feedID string) (*data.Feed, *http.Response, error) {
+	return s.GetWithContext(context.Background(), sourceID, feedID)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *DataFeedsService) GetWithContext(ctx context.Context, sourceID string, feedID string) (*data.Feed, *http.Response, error) {
 	path := fmt.Sprintf("data/feeds/%s/%s", sourceID, feedID)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var df data.Feed
 	resp, err := s.client.Do(req, &df)
@@ -54,12 +67,18 @@ func (s *DataFeedsService) Get(sourceID string, feedID string) (*data.Feed, *htt
 //
 // NS1 API docs: https://ns1.com/api/#feeds-put
 func (s *DataFeedsService) Create(sourceID string, df *data.Feed) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), sourceID, df)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *DataFeedsService) CreateWithContext(ctx context.Context, sourceID string, df *data.Feed) (*http.Response, error) {
 	path := fmt.Sprintf("data/feeds/%s", sourceID)
 
 	req, err := s.client.NewRequest("PUT", path, &df)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update datafeeds' fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &df)
@@ -80,12 +99,18 @@ func (s *DataFeedsService) Create(sourceID string, df *data.Feed) (*http.Respons
 //
 // NS1 API docs: https://ns1.com/api/#feeds-post
 func (s *DataFeedsService) Update(sourceID string, df *data.Feed) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), sourceID, df)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *DataFeedsService) UpdateWithContext(ctx context.Context, sourceID string, df *data.Feed) (*http.Response, error) {
 	path := fmt.Sprintf("data/feeds/%s/%s", sourceID, df.ID)
 
 	req, err := s.client.NewRequest("POST", path, &df)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update df instance fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &df)
@@ -100,12 +125,18 @@ func (s *DataFeedsService) Update(sourceID string, df *data.Feed) (*http.Respons
 //
 // NS1 API docs: https://ns1.com/api/#feeds-delete
 func (s *DataFeedsService) Delete(sourceID string, feedID string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), sourceID, feedID)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *DataFeedsService) DeleteWithContext(ctx context.Context, sourceID string, feedID string) (*http.Response, error) {
 	path := fmt.Sprintf("data/feeds/%s/%s", sourceID, feedID)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/data_source.go
+++ b/rest/data_source.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -14,10 +15,16 @@ type DataSourcesService service
 //
 // NS1 API docs: https://ns1.com/api/#sources-get
 func (s *DataSourcesService) List() ([]*data.Source, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *DataSourcesService) ListWithContext(ctx context.Context) ([]*data.Source, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "data/sources", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	dsl := []*data.Source{}
 	resp, err := s.client.Do(req, &dsl)
@@ -32,12 +39,18 @@ func (s *DataSourcesService) List() ([]*data.Source, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#sources-source-get
 func (s *DataSourcesService) Get(id string) (*data.Source, *http.Response, error) {
+	return s.GetWithContext(context.Background(), id)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *DataSourcesService) GetWithContext(ctx context.Context, id string) (*data.Source, *http.Response, error) {
 	path := fmt.Sprintf("data/sources/%s", id)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var ds data.Source
 	resp, err := s.client.Do(req, &ds)
@@ -52,10 +65,16 @@ func (s *DataSourcesService) Get(id string) (*data.Source, *http.Response, error
 //
 // NS1 API docs: https://ns1.com/api/#sources-put
 func (s *DataSourcesService) Create(ds *data.Source) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), ds)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *DataSourcesService) CreateWithContext(ctx context.Context, ds *data.Source) (*http.Response, error) {
 	req, err := s.client.NewRequest("PUT", "data/sources", &ds)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update data sources' fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &ds)
@@ -71,12 +90,18 @@ func (s *DataSourcesService) Create(ds *data.Source) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#sources-post
 func (s *DataSourcesService) Update(ds *data.Source) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), ds)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *DataSourcesService) UpdateWithContext(ctx context.Context, ds *data.Source) (*http.Response, error) {
 	path := fmt.Sprintf("data/sources/%s", ds.ID)
 
 	req, err := s.client.NewRequest("POST", path, &ds)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update data sources' instance fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &ds)
@@ -91,12 +116,18 @@ func (s *DataSourcesService) Update(ds *data.Source) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#sources-delete
 func (s *DataSourcesService) Delete(id string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), id)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *DataSourcesService) DeleteWithContext(ctx context.Context, id string) (*http.Response, error) {
 	path := fmt.Sprintf("data/sources/%s", id)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
@@ -110,12 +141,18 @@ func (s *DataSourcesService) Delete(id string) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#feed-post
 func (s *DataSourcesService) Publish(dsID string, data interface{}) (*http.Response, error) {
+	return s.PublishWithContext(context.Background(), dsID, data)
+}
+
+// PublishWithContext is the same as Publish, but takes a context.
+func (s *DataSourcesService) PublishWithContext(ctx context.Context, dsID string, data interface{}) (*http.Response, error) {
 	path := fmt.Sprintf("feed/%s", dsID)
 
 	req, err := s.client.NewRequest("POST", path, &data)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/dns_view.go
+++ b/rest/dns_view.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type DNSViewService service
 //
 // NS1 API docs: https://ns1.com/api#getlist-all-dns-views
 func (s *DNSViewService) List() ([]*dns.DNSView, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *DNSViewService) ListWithContext(ctx context.Context) ([]*dns.DNSView, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "views", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var vl []*dns.DNSView
 	resp, err := s.client.Do(req, &vl)
@@ -34,10 +41,16 @@ func (s *DNSViewService) List() ([]*dns.DNSView, *http.Response, error) {
 // The given DNSView must have at least the name
 // NS1 API docs: https://ns1.com/api#putcreate-a-dns-view
 func (s *DNSViewService) Create(v *dns.DNSView) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), v)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *DNSViewService) CreateWithContext(ctx context.Context, v *dns.DNSView) (*http.Response, error) {
 	req, err := s.client.NewRequest("PUT", fmt.Sprintf("/v1/views/%s", v.Name), v)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
@@ -58,12 +71,18 @@ func (s *DNSViewService) Create(v *dns.DNSView) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#getview-dns-view-details
 func (s *DNSViewService) Get(viewName string) (*dns.DNSView, *http.Response, error) {
+	return s.GetWithContext(context.Background(), viewName)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *DNSViewService) GetWithContext(ctx context.Context, viewName string) (*dns.DNSView, *http.Response, error) {
 	path := fmt.Sprintf("views/%s", viewName)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var v dns.DNSView
 	resp, err := s.client.Do(req, &v)
@@ -84,12 +103,18 @@ func (s *DNSViewService) Get(viewName string) (*dns.DNSView, *http.Response, err
 //
 // NS1 API docs: https://ns1.com/api#postedit-a-dns-view
 func (s *DNSViewService) Update(v *dns.DNSView) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), v)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *DNSViewService) UpdateWithContext(ctx context.Context, v *dns.DNSView) (*http.Response, error) {
 	path := fmt.Sprintf("views/%s", v.Name)
 
 	req, err := s.client.NewRequest("POST", path, &v)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, &v)
 	if err != nil {
@@ -109,12 +134,18 @@ func (s *DNSViewService) Update(v *dns.DNSView) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#deletedelete-a-dns-view
 func (s *DNSViewService) Delete(viewName string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), viewName)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *DNSViewService) DeleteWithContext(ctx context.Context, viewName string) (*http.Response, error) {
 	path := fmt.Sprintf("views/%s", viewName)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
@@ -134,12 +165,18 @@ func (s *DNSViewService) Delete(viewName string) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#getget-dns-view-preference
 func (s *DNSViewService) GetPreferences() (map[string]int, *http.Response, error) {
+	return s.GetPreferencesWithContext(context.Background())
+}
+
+// GetPreferencesWithContext is the same as GetPreferences, but takes a context.
+func (s *DNSViewService) GetPreferencesWithContext(ctx context.Context) (map[string]int, *http.Response, error) {
 	path := "config/views/preference"
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	m := make(map[string]int)
 	resp, err := s.client.Do(req, &m)
@@ -154,12 +191,18 @@ func (s *DNSViewService) GetPreferences() (map[string]int, *http.Response, error
 //
 // NS1 API docs: https://ns1.com/api#postedit-dns-view-preference
 func (s *DNSViewService) UpdatePreferences(m map[string]int) (map[string]int, *http.Response, error) {
+	return s.UpdatePreferencesWithContext(context.Background(), m)
+}
+
+// UpdatePreferencesWithContext is the same as UpdatePreferences, but takes a context.
+func (s *DNSViewService) UpdatePreferencesWithContext(ctx context.Context, m map[string]int) (map[string]int, *http.Response, error) {
 	path := "config/views/preference"
 
 	req, err := s.client.NewRequest("POST", path, m)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	mapUpdated := make(map[string]int)
 	resp, err := s.client.Do(req, &mapUpdated)

--- a/rest/dnssec.go
+++ b/rest/dnssec.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,12 +16,18 @@ type DNSSECService service
 //
 // NS1 API docs: https://ns1.com/api#get-get-dnssec-details-for-a-zone
 func (s *DNSSECService) Get(zone string) (*dns.ZoneDNSSEC, *http.Response, error) {
+	return s.GetWithContext(context.Background(), zone)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *DNSSECService) GetWithContext(ctx context.Context, zone string) (*dns.ZoneDNSSEC, *http.Response, error) {
 	path := fmt.Sprintf("zones/%s/dnssec", zone)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var d dns.ZoneDNSSEC
 	resp, err := s.client.Do(req, &d)

--- a/rest/ipam.go
+++ b/rest/ipam.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -16,10 +17,16 @@ type IPAMService service
 //
 // NS1 API docs: https://ns1.com/api#getview-a-list-of-root-addresses
 func (s *IPAMService) ListAddrs() ([]ipam.Address, *http.Response, error) {
+	return s.ListAddrsWithContext(context.Background())
+}
+
+// ListAddrsWithContext is the same as ListAddrs, but takes a context.
+func (s *IPAMService) ListAddrsWithContext(ctx context.Context) ([]ipam.Address, *http.Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "ipam/address", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	addrs := []ipam.Address{}
 	var resp *http.Response
@@ -39,11 +46,17 @@ func (s *IPAMService) ListAddrs() ([]ipam.Address, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#getview-a-subnet
 func (s *IPAMService) GetSubnet(addrID int) (*ipam.Address, *http.Response, error) {
+	return s.GetSubnetWithContext(context.Background(), addrID)
+}
+
+// GetSubnetWithContext is the same as GetSubnet, but takes a context.
+func (s *IPAMService) GetSubnetWithContext(ctx context.Context, addrID int) (*ipam.Address, *http.Response, error) {
 	reqPath := fmt.Sprintf("ipam/address/%d", addrID)
 	req, err := s.client.NewRequest(http.MethodGet, reqPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	addr := &ipam.Address{}
 	var resp *http.Response
@@ -60,11 +73,17 @@ func (s *IPAMService) GetSubnet(addrID int) (*ipam.Address, *http.Response, erro
 //
 // NS1 API docs: https://ns1.com/api#getview-address-children
 func (s *IPAMService) GetChildren(addrID int) ([]*ipam.Address, *http.Response, error) {
+	return s.GetChildrenWithContext(context.Background(), addrID)
+}
+
+// GetChildrenWithContext is the same as GetChildren, but takes a context.
+func (s *IPAMService) GetChildrenWithContext(ctx context.Context, addrID int) ([]*ipam.Address, *http.Response, error) {
 	reqPath := fmt.Sprintf("ipam/address/%d/children", addrID)
 	req, err := s.client.NewRequest(http.MethodGet, reqPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	addrs := []*ipam.Address{}
 	var resp *http.Response
@@ -84,11 +103,17 @@ func (s *IPAMService) GetChildren(addrID int) ([]*ipam.Address, *http.Response, 
 //
 // NS1 API docs: https://ns1.com/api#getview-address-parent
 func (s *IPAMService) GetParent(addrID int) (*ipam.Address, *http.Response, error) {
+	return s.GetParentWithContext(context.Background(), addrID)
+}
+
+// GetParentWithContext is the same as GetParent, but takes a context.
+func (s *IPAMService) GetParentWithContext(ctx context.Context, addrID int) (*ipam.Address, *http.Response, error) {
 	reqPath := fmt.Sprintf("ipam/address/%d/parent", addrID)
 	req, err := s.client.NewRequest(http.MethodGet, reqPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	addr := &ipam.Address{}
 	var resp *http.Response
@@ -105,6 +130,11 @@ func (s *IPAMService) GetParent(addrID int) (*ipam.Address, *http.Response, erro
 //
 // NS1 API docs: https://ns1.com/api#putcreate-a-subnet
 func (s *IPAMService) CreateSubnet(addr *ipam.Address) (*ipam.Address, *http.Response, error) {
+	return s.CreateSubnetWithContext(context.Background(), addr)
+}
+
+// CreateSubnetWithContext is the same as CreateSubnet, but takes a context.
+func (s *IPAMService) CreateSubnetWithContext(ctx context.Context, addr *ipam.Address) (*ipam.Address, *http.Response, error) {
 	switch {
 	case addr.Prefix == "":
 		return nil, nil, errors.New("the Prefix field is required")
@@ -116,6 +146,7 @@ func (s *IPAMService) CreateSubnet(addr *ipam.Address) (*ipam.Address, *http.Res
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	respAddr := &ipam.Address{}
 	var resp *http.Response
@@ -133,6 +164,11 @@ func (s *IPAMService) CreateSubnet(addr *ipam.Address) (*ipam.Address, *http.Res
 //
 // NS1 API docs: https://ns1.com/api#postedit-a-subnet
 func (s *IPAMService) EditSubnet(addr *ipam.Address, parent bool) (newAddr, parentAddr *ipam.Address, resp *http.Response, err error) {
+	return s.EditSubnetWithContext(context.Background(), addr, parent)
+}
+
+// EditSubnetWithContext is the same as EditSubnet, but takes a context.
+func (s *IPAMService) EditSubnetWithContext(ctx context.Context, addr *ipam.Address, parent bool) (newAddr, parentAddr *ipam.Address, resp *http.Response, err error) {
 	if addr.ID == 0 {
 		return nil, nil, nil, errors.New("the ID field is required")
 	}
@@ -142,6 +178,7 @@ func (s *IPAMService) EditSubnet(addr *ipam.Address, parent bool) (newAddr, pare
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	req = req.WithContext(ctx)
 	if parent {
 		q := req.URL.Query()
 		q.Add("parent", "true")
@@ -174,6 +211,11 @@ func (s *IPAMService) EditSubnet(addr *ipam.Address, parent bool) (newAddr, pare
 //
 // NS1 API docs: https://ns1.com/api#postsplit-a-subnet
 func (s *IPAMService) SplitSubnet(id, prefix int) (rootAddr int, prefixIDs []int, resp *http.Response, err error) {
+	return s.SplitSubnetWithContext(context.Background(), id, prefix)
+}
+
+// SplitSubnetWithContext is the same as SplitSubnet, but takes a context.
+func (s *IPAMService) SplitSubnetWithContext(ctx context.Context, id, prefix int) (rootAddr int, prefixIDs []int, resp *http.Response, err error) {
 	reqPath := fmt.Sprintf("ipam/address/%d/split", id)
 	req, err := s.client.NewRequest(http.MethodPost, reqPath, struct {
 		Prefix int `json:"prefix"`
@@ -183,6 +225,7 @@ func (s *IPAMService) SplitSubnet(id, prefix int) (rootAddr int, prefixIDs []int
 	if err != nil {
 		return 0, nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	data := &struct {
 		RootAddr  int   `json:"root_address_id"`
@@ -196,6 +239,11 @@ func (s *IPAMService) SplitSubnet(id, prefix int) (rootAddr int, prefixIDs []int
 //
 // NS1 API docs: https://ns1.com/api#postmerge-a-subnet
 func (s *IPAMService) MergeSubnet(rootID, mergeID int) (*ipam.Address, *http.Response, error) {
+	return s.MergeSubnetWithContext(context.Background(), rootID, mergeID)
+}
+
+// MergeSubnetWithContext is the same as MergeSubnet, but takes a context.
+func (s *IPAMService) MergeSubnetWithContext(ctx context.Context, rootID, mergeID int) (*ipam.Address, *http.Response, error) {
 	req, err := s.client.NewRequest(http.MethodPost, "ipam/address/merge", struct {
 		Root  int `json:"root_address_id"`
 		Merge int `json:"merged_address_id"`
@@ -206,6 +254,7 @@ func (s *IPAMService) MergeSubnet(rootID, mergeID int) (*ipam.Address, *http.Res
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	addr := &ipam.Address{}
 	resp, err := s.client.Do(req, &addr)
@@ -216,11 +265,17 @@ func (s *IPAMService) MergeSubnet(rootID, mergeID int) (*ipam.Address, *http.Res
 //
 // NS1 API docs: https://ns1.com/api#deletedelete-a-subnet
 func (s *IPAMService) DeleteSubnet(id int) (*http.Response, error) {
+	return s.DeleteSubnetWithContext(context.Background(), id)
+}
+
+// DeleteSubnetWithContext is the same as DeleteSubnet, but takes a context.
+func (s *IPAMService) DeleteSubnetWithContext(ctx context.Context, id int) (*http.Response, error) {
 	reqPath := fmt.Sprintf("ipam/address/%d", id)
 	req, err := s.client.NewRequest(http.MethodDelete, reqPath, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	return s.client.Do(req, nil)
 }

--- a/rest/monitor_job.go
+++ b/rest/monitor_job.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,10 +16,16 @@ type JobsService service
 //
 // NS1 API docs: https://ns1.com/api/#jobs-get
 func (s *JobsService) List() ([]*monitor.Job, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *JobsService) ListWithContext(ctx context.Context) ([]*monitor.Job, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "monitoring/jobs", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	mjl := []*monitor.Job{}
 	resp, err := s.client.Do(req, &mjl)
@@ -33,12 +40,18 @@ func (s *JobsService) List() ([]*monitor.Job, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#jobs-jobid-get
 func (s *JobsService) Get(id string) (*monitor.Job, *http.Response, error) {
+	return s.GetWithContext(context.Background(), id)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *JobsService) GetWithContext(ctx context.Context, id string) (*monitor.Job, *http.Response, error) {
 	path := fmt.Sprintf("%s/%s", "monitoring/jobs", id)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var mj monitor.Job
 	resp, err := s.client.Do(req, &mj)
@@ -53,12 +66,18 @@ func (s *JobsService) Get(id string) (*monitor.Job, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#jobs-put
 func (s *JobsService) Create(mj *monitor.Job) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), mj)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *JobsService) CreateWithContext(ctx context.Context, mj *monitor.Job) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s", "monitoring/jobs", mj.ID)
 
 	req, err := s.client.NewRequest("PUT", path, &mj)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update mon jobs' fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &mj)
@@ -73,12 +92,18 @@ func (s *JobsService) Create(mj *monitor.Job) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#jobs-jobid-post
 func (s *JobsService) Update(mj *monitor.Job) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), mj)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *JobsService) UpdateWithContext(ctx context.Context, mj *monitor.Job) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s", "monitoring/jobs", mj.ID)
 
 	req, err := s.client.NewRequest("POST", path, &mj)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update mon jobs' fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &mj)
@@ -93,12 +118,18 @@ func (s *JobsService) Update(mj *monitor.Job) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#jobs-jobid-delete
 func (s *JobsService) Delete(id string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), id)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *JobsService) DeleteWithContext(ctx context.Context, id string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s", "monitoring/jobs", id)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {
@@ -112,6 +143,11 @@ func (s *JobsService) Delete(id string) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#history-get
 func (s *JobsService) History(id string, opts ...func(*url.Values)) ([]*monitor.StatusLog, *http.Response, error) {
+	return s.HistoryWithContext(context.Background(), id, opts...)
+}
+
+// HistoryWithContext is the same as History, but takes a context.
+func (s *JobsService) HistoryWithContext(ctx context.Context, id string, opts ...func(*url.Values)) ([]*monitor.StatusLog, *http.Response, error) {
 	v := url.Values{}
 	for _, opt := range opts {
 		opt(&v)
@@ -123,6 +159,7 @@ func (s *JobsService) History(id string, opts ...func(*url.Values)) ([]*monitor.
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var slgs []*monitor.StatusLog
 	resp, err := s.client.Do(req, &slgs)

--- a/rest/monitor_notify.go
+++ b/rest/monitor_notify.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type NotificationsService service
 //
 // NS1 API docs: https://ns1.com/api/#lists-get
 func (s *NotificationsService) List() ([]*monitor.NotifyList, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *NotificationsService) ListWithContext(ctx context.Context) ([]*monitor.NotifyList, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "lists", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	nl := []*monitor.NotifyList{}
 	resp, err := s.client.Do(req, &nl)
@@ -33,12 +40,18 @@ func (s *NotificationsService) List() ([]*monitor.NotifyList, *http.Response, er
 //
 // NS1 API docs: https://ns1.com/api/#lists-listid-get
 func (s *NotificationsService) Get(listID string) (*monitor.NotifyList, *http.Response, error) {
+	return s.GetWithContext(context.Background(), listID)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *NotificationsService) GetWithContext(ctx context.Context, listID string) (*monitor.NotifyList, *http.Response, error) {
 	path := fmt.Sprintf("%s/%s", "lists", listID)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var nl monitor.NotifyList
 	resp, err := s.client.Do(req, &nl)
@@ -59,10 +72,16 @@ func (s *NotificationsService) Get(listID string) (*monitor.NotifyList, *http.Re
 //
 // NS1 API docs: https://ns1.com/api/#lists-put
 func (s *NotificationsService) Create(nl *monitor.NotifyList) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), nl)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *NotificationsService) CreateWithContext(ctx context.Context, nl *monitor.NotifyList) (*http.Response, error) {
 	req, err := s.client.NewRequest("PUT", "lists", &nl)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update notify list fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &nl)
@@ -83,12 +102,18 @@ func (s *NotificationsService) Create(nl *monitor.NotifyList) (*http.Response, e
 //
 // NS1 API docs: https://ns1.com/api/#list-listid-post
 func (s *NotificationsService) Update(nl *monitor.NotifyList) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), nl)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *NotificationsService) UpdateWithContext(ctx context.Context, nl *monitor.NotifyList) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s", "lists", nl.ID)
 
 	req, err := s.client.NewRequest("POST", path, &nl)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update mon lists' fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &nl)
@@ -103,12 +128,18 @@ func (s *NotificationsService) Update(nl *monitor.NotifyList) (*http.Response, e
 //
 // NS1 API docs: https://ns1.com/api/#lists-listid-delete
 func (s *NotificationsService) Delete(listID string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), listID)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *NotificationsService) DeleteWithContext(ctx context.Context, listID string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s", "lists", listID)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/optiondef.go
+++ b/rest/optiondef.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dhcp"
@@ -14,10 +15,16 @@ type OptionDefService service
 //
 // NS1 API docs: https://ns1.com/api#getlist-dhcp-option-definitions
 func (s *OptionDefService) List() ([]dhcp.OptionDef, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *OptionDefService) ListWithContext(ctx context.Context) ([]dhcp.OptionDef, *http.Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "dhcp/optiondef", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	ods := make([]dhcp.OptionDef, 0)
 	resp, err := s.client.Do(req, &ods)
@@ -28,11 +35,17 @@ func (s *OptionDefService) List() ([]dhcp.OptionDef, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#getview-dhcp-option-definition
 func (s *OptionDefService) Get(odSpace, odKey string) (*dhcp.OptionDef, *http.Response, error) {
+	return s.GetWithContext(context.Background(), odSpace, odKey)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *OptionDefService) GetWithContext(ctx context.Context, odSpace, odKey string) (*dhcp.OptionDef, *http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/optiondef/%s/%s", odSpace, odKey)
 	req, err := s.client.NewRequest(http.MethodGet, reqPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	od := &dhcp.OptionDef{}
 	var resp *http.Response
@@ -49,6 +62,11 @@ func (s *OptionDefService) Get(odSpace, odKey string) (*dhcp.OptionDef, *http.Re
 //
 // NS1 API docs: https://ns1.com/api#putcreate-an-custom-dhcp-option-definition
 func (s *OptionDefService) Create(od *dhcp.OptionDef, odSpace, odKey string) (*dhcp.OptionDef, *http.Response, error) {
+	return s.CreateWithContext(context.Background(), od, odSpace, odKey)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *OptionDefService) CreateWithContext(ctx context.Context, od *dhcp.OptionDef, odSpace, odKey string) (*dhcp.OptionDef, *http.Response, error) {
 	switch {
 	case od.FriendlyName == "":
 		return nil, nil, errors.New("the FriendlyName field is required")
@@ -65,6 +83,7 @@ func (s *OptionDefService) Create(od *dhcp.OptionDef, odSpace, odKey string) (*d
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	respOd := new(dhcp.OptionDef)
 	var resp *http.Response
@@ -80,11 +99,17 @@ func (s *OptionDefService) Create(od *dhcp.OptionDef, odSpace, odKey string) (*d
 //
 // NS1 API docs: https://ns1.com/api#deletedelete-a-custom-dhcp-option-definition
 func (s *OptionDefService) Delete(odSpace, odKey string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), odSpace, odKey)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *OptionDefService) DeleteWithContext(ctx context.Context, odSpace, odKey string) (*http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/optiondef/%s/%s", odSpace, odKey)
 	req, err := s.client.NewRequest(http.MethodDelete, reqPath, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	return s.client.Do(req, nil)
 }

--- a/rest/pulsar_job.go
+++ b/rest/pulsar_job.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,11 +16,17 @@ type PulsarJobsService service
 //
 // NS1 API docs: https://ns1.com/api/#getlist-jobs-within-an-app
 func (s *PulsarJobsService) List(appId string) ([]*pulsar.PulsarJob, *http.Response, error) {
+	return s.ListWithContext(context.Background(), appId)
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *PulsarJobsService) ListWithContext(ctx context.Context, appId string) ([]*pulsar.PulsarJob, *http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs", appId)
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	jl := []*pulsar.PulsarJob{}
 	var resp *http.Response
@@ -41,12 +48,18 @@ func (s *PulsarJobsService) List(appId string) ([]*pulsar.PulsarJob, *http.Respo
 //
 // NS1 API docs: https://ns1.com/api/#getview-job-details
 func (s *PulsarJobsService) Get(appId string, jobId string) (*pulsar.PulsarJob, *http.Response, error) {
+	return s.GetWithContext(context.Background(), appId, jobId)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *PulsarJobsService) GetWithContext(ctx context.Context, appId string, jobId string) (*pulsar.PulsarJob, *http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs/%s", appId, jobId)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var job pulsar.PulsarJob
 
@@ -73,12 +86,18 @@ func (s *PulsarJobsService) Get(appId string, jobId string) (*pulsar.PulsarJob, 
 //
 // NS1 API docs: https://ns1.com/api/#putcreate-a-pulsar-job
 func (s *PulsarJobsService) Create(j *pulsar.PulsarJob) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), j)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *PulsarJobsService) CreateWithContext(ctx context.Context, j *pulsar.PulsarJob) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs", j.AppID)
 
 	req, err := s.client.NewRequest("PUT", path, j)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update job fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, j)
@@ -100,12 +119,18 @@ func (s *PulsarJobsService) Create(j *pulsar.PulsarJob) (*http.Response, error) 
 // Only the fields to be updated are required in the given job.
 // NS1 API docs: https://ns1.com/api/#postmodify-a-pulsar-job
 func (s *PulsarJobsService) Update(j *pulsar.PulsarJob) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), j)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *PulsarJobsService) UpdateWithContext(ctx context.Context, j *pulsar.PulsarJob) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs/%s", j.AppID, j.JobID)
 
 	req, err := s.client.NewRequest("POST", path, j)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update jobs fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, j)
@@ -130,12 +155,18 @@ func (s *PulsarJobsService) Update(j *pulsar.PulsarJob) (*http.Response, error) 
 //
 // NS1 API docs: https://ns1.com/api/#deletedelete-a-pulsar-job
 func (s *PulsarJobsService) Delete(pulsarJob *pulsar.PulsarJob) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), pulsarJob)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *PulsarJobsService) DeleteWithContext(ctx context.Context, pulsarJob *pulsar.PulsarJob) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs/%s", pulsarJob.AppID, pulsarJob.JobID)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/record.go
+++ b/rest/record.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,12 +16,18 @@ type RecordsService service
 //
 // NS1 API docs: https://ns1.com/api/#record-get
 func (s *RecordsService) Get(zone, domain, t string) (*dns.Record, *http.Response, error) {
+	return s.GetWithContext(context.Background(), zone, domain, t)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *RecordsService) GetWithContext(ctx context.Context, zone, domain, t string) (*dns.Record, *http.Response, error) {
 	path := fmt.Sprintf("zones/%s/%s/%s", zone, domain, t)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var r dns.Record
 	resp, err := s.client.Do(req, &r)
@@ -42,12 +49,18 @@ func (s *RecordsService) Get(zone, domain, t string) (*dns.Record, *http.Respons
 // The given record must have at least one answer.
 // NS1 API docs: https://ns1.com/api/#record-put
 func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), r)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *RecordsService) CreateWithContext(ctx context.Context, r *dns.Record) (*http.Response, error) {
 	path := fmt.Sprintf("zones/%s/%s/%s", r.Zone, r.Domain, r.Type)
 
 	req, err := s.client.NewRequest("PUT", path, &r)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update record fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &r)
@@ -72,12 +85,18 @@ func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
 // Only the fields to be updated are required in the given record.
 // NS1 API docs: https://ns1.com/api/#record-post
 func (s *RecordsService) Update(r *dns.Record) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), r)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *RecordsService) UpdateWithContext(ctx context.Context, r *dns.Record) (*http.Response, error) {
 	path := fmt.Sprintf("zones/%s/%s/%s", r.Zone, r.Domain, r.Type)
 
 	req, err := s.client.NewRequest("POST", path, &r)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update records fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &r)
@@ -103,12 +122,18 @@ func (s *RecordsService) Update(r *dns.Record) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#record-delete
 func (s *RecordsService) Delete(zone string, domain string, t string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), zone, domain, t)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *RecordsService) DeleteWithContext(ctx context.Context, zone string, domain string, t string) (*http.Response, error) {
 	path := fmt.Sprintf("zones/%s/%s/%s", zone, domain, t)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/reservation.go
+++ b/rest/reservation.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type ReservationService service
 //
 // NS1 API docs: https://ns1.com/api#getlist-reservations
 func (s *ReservationService) List() ([]dhcp.Reservation, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *ReservationService) ListWithContext(ctx context.Context) ([]dhcp.Reservation, *http.Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "dhcp/reservation", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	scs := make([]dhcp.Reservation, 0)
 	resp, err := s.client.Do(req, &scs)
@@ -33,11 +40,17 @@ func (s *ReservationService) List() ([]dhcp.Reservation, *http.Response, error) 
 //
 // NS1 API docs: https://ns1.com/api#getview-a-reservations-details
 func (s *ReservationService) Get(scID int) (*dhcp.Reservation, *http.Response, error) {
+	return s.GetWithContext(context.Background(), scID)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *ReservationService) GetWithContext(ctx context.Context, scID int) (*dhcp.Reservation, *http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/reservation/%d", scID)
 	req, err := s.client.NewRequest(http.MethodGet, reqPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	sc := &dhcp.Reservation{}
 	var resp *http.Response
@@ -54,6 +67,11 @@ func (s *ReservationService) Get(scID int) (*dhcp.Reservation, *http.Response, e
 //
 // NS1 API docs: https://ns1.com/api#putcreate-a-reservation
 func (s *ReservationService) Create(sc *dhcp.Reservation) (*dhcp.Reservation, *http.Response, error) {
+	return s.CreateWithContext(context.Background(), sc)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *ReservationService) CreateWithContext(ctx context.Context, sc *dhcp.Reservation) (*dhcp.Reservation, *http.Response, error) {
 	switch {
 	case sc.Options == nil:
 		return nil, nil, errors.New("the Options field is required")
@@ -63,6 +81,7 @@ func (s *ReservationService) Create(sc *dhcp.Reservation) (*dhcp.Reservation, *h
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	respSc := new(dhcp.Reservation)
 	var resp *http.Response
@@ -79,6 +98,11 @@ func (s *ReservationService) Create(sc *dhcp.Reservation) (*dhcp.Reservation, *h
 //
 // NS1 API docs: https://ns1.com/api#postmodify-a-reservation
 func (s *ReservationService) Edit(sc *dhcp.Reservation) (*dhcp.Reservation, *http.Response, error) {
+	return s.EditWithContext(context.Background(), sc)
+}
+
+// EditWithContext is the same as Edit, but takes a context.
+func (s *ReservationService) EditWithContext(ctx context.Context, sc *dhcp.Reservation) (*dhcp.Reservation, *http.Response, error) {
 	switch {
 	case sc.ID == nil:
 		return nil, nil, errors.New("the ID field is required")
@@ -91,6 +115,7 @@ func (s *ReservationService) Edit(sc *dhcp.Reservation) (*dhcp.Reservation, *htt
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, sc)
 	if err != nil {
@@ -104,11 +129,17 @@ func (s *ReservationService) Edit(sc *dhcp.Reservation) (*dhcp.Reservation, *htt
 //
 // NS1 API docs: https://ns1.com/api#deletedelete-a-reservation
 func (s *ReservationService) Delete(id int) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), id)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *ReservationService) DeleteWithContext(ctx context.Context, id int) (*http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/reservation/%d", id)
 	req, err := s.client.NewRequest(http.MethodDelete, reqPath, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	return s.client.Do(req, nil)
 }

--- a/rest/scope.go
+++ b/rest/scope.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type ScopeService service
 //
 // NS1 API docs: https://ns1.com/api#getlist-scopes
 func (s *ScopeService) List() ([]dhcp.Scope, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *ScopeService) ListWithContext(ctx context.Context) ([]dhcp.Scope, *http.Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "dhcp/scope", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	scs := make([]dhcp.Scope, 0)
 	resp, err := s.client.Do(req, &scs)
@@ -33,11 +40,17 @@ func (s *ScopeService) List() ([]dhcp.Scope, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#getview-scope-details
 func (s *ScopeService) Get(scID int) (*dhcp.Scope, *http.Response, error) {
+	return s.GetWithContext(context.Background(), scID)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *ScopeService) GetWithContext(ctx context.Context, scID int) (*dhcp.Scope, *http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/scope/%d", scID)
 	req, err := s.client.NewRequest(http.MethodGet, reqPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	sc := &dhcp.Scope{}
 	var resp *http.Response
@@ -54,6 +67,11 @@ func (s *ScopeService) Get(scID int) (*dhcp.Scope, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#putcreate-a-scope
 func (s *ScopeService) Create(sc *dhcp.Scope) (*dhcp.Scope, *http.Response, error) {
+	return s.CreateWithContext(context.Background(), sc)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *ScopeService) CreateWithContext(ctx context.Context, sc *dhcp.Scope) (*dhcp.Scope, *http.Response, error) {
 	switch {
 	case sc.IDAddress == nil:
 		return nil, nil, errors.New("the IDAddress field is required")
@@ -63,6 +81,7 @@ func (s *ScopeService) Create(sc *dhcp.Scope) (*dhcp.Scope, *http.Response, erro
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	respSc := new(dhcp.Scope)
 	var resp *http.Response
@@ -79,6 +98,11 @@ func (s *ScopeService) Create(sc *dhcp.Scope) (*dhcp.Scope, *http.Response, erro
 //
 // NS1 API docs: https://ns1.com/api#postmodify-a-scope
 func (s *ScopeService) Edit(sc *dhcp.Scope) (*dhcp.Scope, *http.Response, error) {
+	return s.EditWithContext(context.Background(), sc)
+}
+
+// CreateWithContext is the same as Edit, but takes a context.
+func (s *ScopeService) EditWithContext(ctx context.Context, sc *dhcp.Scope) (*dhcp.Scope, *http.Response, error) {
 	switch {
 	case sc.IDAddress == nil:
 		return nil, nil, errors.New("the IDAddress field is required")
@@ -89,6 +113,7 @@ func (s *ScopeService) Edit(sc *dhcp.Scope) (*dhcp.Scope, *http.Response, error)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, sc)
 	if err != nil {
@@ -102,11 +127,17 @@ func (s *ScopeService) Edit(sc *dhcp.Scope) (*dhcp.Scope, *http.Response, error)
 //
 // NS1 API docs: https://ns1.com/api#deleteremove-a-scope
 func (s *ScopeService) Delete(id int) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), id)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *ScopeService) DeleteWithContext(ctx context.Context, id int) (*http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/scope/%d", id)
 	req, err := s.client.NewRequest(http.MethodDelete, reqPath, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	return s.client.Do(req, nil)
 }

--- a/rest/scopegroup.go
+++ b/rest/scopegroup.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dhcp"
@@ -14,10 +15,16 @@ type ScopeGroupService service
 //
 // NS1 API docs: https://ns1.com/api#getlist-scope-groups
 func (s *ScopeGroupService) List() ([]dhcp.ScopeGroup, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *ScopeGroupService) ListWithContext(ctx context.Context) ([]dhcp.ScopeGroup, *http.Response, error) {
 	req, err := s.client.NewRequest(http.MethodGet, "dhcp/scopegroup", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	sgs := make([]dhcp.ScopeGroup, 0)
 	resp, err := s.client.Do(req, &sgs)
@@ -28,11 +35,17 @@ func (s *ScopeGroupService) List() ([]dhcp.ScopeGroup, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api#getview-scope-group
 func (s *ScopeGroupService) Get(sgID int) (*dhcp.ScopeGroup, *http.Response, error) {
+	return s.GetWithContext(context.Background(), sgID)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *ScopeGroupService) GetWithContext(ctx context.Context, sgID int) (*dhcp.ScopeGroup, *http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/scopegroup/%d", sgID)
 	req, err := s.client.NewRequest(http.MethodGet, reqPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	sg := &dhcp.ScopeGroup{}
 	var resp *http.Response
@@ -49,6 +62,11 @@ func (s *ScopeGroupService) Get(sgID int) (*dhcp.ScopeGroup, *http.Response, err
 //
 // NS1 API docs: https://ns1.com/api#putcreate-a-scope-group
 func (s *ScopeGroupService) Create(sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http.Response, error) {
+	return s.CreateWithContext(context.Background(), sg)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *ScopeGroupService) CreateWithContext(ctx context.Context, sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http.Response, error) {
 	switch {
 	case sg.Name == "":
 		return nil, nil, errors.New("the Name field is required")
@@ -58,6 +76,7 @@ func (s *ScopeGroupService) Create(sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	respSg := new(dhcp.ScopeGroup)
 	var resp *http.Response
@@ -74,6 +93,11 @@ func (s *ScopeGroupService) Create(sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http
 //
 // NS1 API docs: https://ns1.com/api#postedit-scope-group
 func (s *ScopeGroupService) Edit(sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http.Response, error) {
+	return s.EditWithContext(context.Background(), sg)
+}
+
+// EditWithContext is the same as Edit, but takes a context.
+func (s *ScopeGroupService) EditWithContext(ctx context.Context, sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http.Response, error) {
 	if sg.ID == nil {
 		return nil, nil, errors.New("the ID field is required")
 	}
@@ -83,6 +107,7 @@ func (s *ScopeGroupService) Edit(sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http.R
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, sg)
 	if err != nil {
@@ -96,6 +121,11 @@ func (s *ScopeGroupService) Edit(sg *dhcp.ScopeGroup) (*dhcp.ScopeGroup, *http.R
 //
 // NS1 API docs: https://ns1.com/api#deleteremove-scope-group-by-id
 func (s *ScopeGroupService) Delete(id int) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), id)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *ScopeGroupService) DeleteWithContext(ctx context.Context, id int) (*http.Response, error) {
 	reqPath := fmt.Sprintf("dhcp/scopegroup/%d", id)
 	req, err := s.client.NewRequest(http.MethodDelete, reqPath, nil)
 	if err != nil {

--- a/rest/stat.go
+++ b/rest/stat.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -14,30 +15,46 @@ type StatsService service
 // The QPS number is lagged by approximately 30 seconds for statistics collection;
 // and the rate is computed over the preceding minute.
 func (s *StatsService) GetQPS() (float32, *http.Response, error) {
-	return s.getQPS(statsQPSEndpoint)
+	return s.GetQPSWithContext(context.Background())
+}
+
+// GetQPSWithContext is the same as GetQPS, but takes a context.
+func (s *StatsService) GetQPSWithContext(ctx context.Context) (float32, *http.Response, error) {
+	return s.getQPS(ctx, statsQPSEndpoint)
 }
 
 // GetZoneQPS returns current queries per second (QPS) for a specific zone.
 // The QPS number is lagged by approximately 30 seconds for statistics collection;
 // and the rate is computed over the preceding minute.
 func (s *StatsService) GetZoneQPS(zone string) (float32, *http.Response, error) {
+	return s.GetZoneQPSWithContext(context.Background(), zone)
+}
+
+// GetZoneQPSWithContext is the same as GetZoneQPS, but takes a context.
+func (s *StatsService) GetZoneQPSWithContext(ctx context.Context, zone string) (float32, *http.Response, error) {
 	path := fmt.Sprintf("%s/%s", statsQPSEndpoint, zone)
-	return s.getQPS(path)
+	return s.getQPS(ctx, path)
 }
 
 // GetRecordQPS returns current queries per second (QPS) for a specific record.
 // The QPS number is lagged by approximately 30 seconds for statistics collection;
 // and the rate is computed over the preceding minute.
 func (s *StatsService) GetRecordQPS(zone, record, t string) (float32, *http.Response, error) {
-	path := fmt.Sprintf("%s/%s/%s/%s", statsQPSEndpoint, zone, record, t)
-	return s.getQPS(path)
+	return s.GetRecordQPSWithContext(context.Background(), zone, record, t)
 }
 
-func (s *StatsService) getQPS(path string) (float32, *http.Response, error) {
+// GetRecordQPSWithContext is the same as GetRecordQPS, but takes a context.
+func (s *StatsService) GetRecordQPSWithContext(ctx context.Context, zone, record, t string) (float32, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s/%s/%s", statsQPSEndpoint, zone, record, t)
+	return s.getQPS(ctx, path)
+}
+
+func (s *StatsService) getQPS(ctx context.Context, path string) (float32, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return 0, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var value struct {
 		/* by default unmartial will ignore any extra fields so we don't need these

--- a/rest/tsig_key.go
+++ b/rest/tsig_key.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type TsigService service
 //
 // NS1 API docs: https://ns1.com/api/#getlist-tsig-keys
 func (s *TsigService) List() ([]*dns.TSIGKey, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *TsigService) ListWithContext(ctx context.Context) ([]*dns.TSIGKey, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "tsig", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	tsigKeyList := []*dns.TSIGKey{}
 	var resp *http.Response
@@ -34,12 +41,18 @@ func (s *TsigService) List() ([]*dns.TSIGKey, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#getview-tsig-key-details
 func (s *TsigService) Get(name string) (*dns.TSIGKey, *http.Response, error) {
+	return s.GetWithContext(context.Background(), name)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *TsigService) GetWithContext(ctx context.Context, name string) (*dns.TSIGKey, *http.Response, error) {
 	path := fmt.Sprintf("tsig/%s", name)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var tk dns.TSIGKey
 	var resp *http.Response
@@ -61,12 +74,18 @@ func (s *TsigService) Get(name string) (*dns.TSIGKey, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#putcreate-a-tsig-key
 func (s *TsigService) Create(tk *dns.TSIGKey) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), tk)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *TsigService) CreateWithContext(ctx context.Context, tk *dns.TSIGKey) (*http.Response, error) {
 	path := fmt.Sprintf("tsig/%s", tk.Name)
 
 	req, err := s.client.NewRequest("PUT", path, &tk)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update TSIG key fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &tk)
@@ -87,12 +106,18 @@ func (s *TsigService) Create(tk *dns.TSIGKey) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#postmodify-a-tsig-key
 func (s *TsigService) Update(tk *dns.TSIGKey) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), tk)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *TsigService) UpdateWithContext(ctx context.Context, tk *dns.TSIGKey) (*http.Response, error) {
 	path := fmt.Sprintf("tsig/%s", tk.Name)
 
 	req, err := s.client.NewRequest("POST", path, &tk)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update TSIG key fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &tk)
@@ -113,12 +138,18 @@ func (s *TsigService) Update(tk *dns.TSIGKey) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#deleteremove-a-tsig-key
 func (s *TsigService) Delete(name string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), name)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *TsigService) DeleteWithContext(ctx context.Context, name string) (*http.Response, error) {
 	path := fmt.Sprintf("tsig/%s", name)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/rest/zone.go
+++ b/rest/zone.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,10 +16,16 @@ type ZonesService service
 //
 // NS1 API docs: https://ns1.com/api/#zones-get
 func (s *ZonesService) List() ([]*dns.Zone, *http.Response, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// ListWithContext is the same as List, but takes a context.
+func (s *ZonesService) ListWithContext(ctx context.Context) ([]*dns.Zone, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "zones", nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	zl := []*dns.Zone{}
 	var resp *http.Response
@@ -38,12 +45,18 @@ func (s *ZonesService) List() ([]*dns.Zone, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#zones-zone-get
 func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
+	return s.GetWithContext(context.Background(), zone)
+}
+
+// GetWithContext is the same as Get, but takes a context.
+func (s *ZonesService) GetWithContext(ctx context.Context, zone string) (*dns.Zone, *http.Response, error) {
 	path := fmt.Sprintf("zones/%s", zone)
 
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+	req = req.WithContext(ctx)
 
 	var z dns.Zone
 	var resp *http.Response
@@ -69,12 +82,18 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#zones-put
 func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
+	return s.CreateWithContext(context.Background(), z)
+}
+
+// CreateWithContext is the same as Create, but takes a context.
+func (s *ZonesService) CreateWithContext(ctx context.Context, z *dns.Zone) (*http.Response, error) {
 	path := fmt.Sprintf("zones/%s", z.Zone)
 
 	req, err := s.client.NewRequest("PUT", path, &z)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update zones fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &z)
@@ -97,12 +116,18 @@ func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#zones-post
 func (s *ZonesService) Update(z *dns.Zone) (*http.Response, error) {
+	return s.UpdateWithContext(context.Background(), z)
+}
+
+// UpdateWithContext is the same as Update, but takes a context.
+func (s *ZonesService) UpdateWithContext(ctx context.Context, z *dns.Zone) (*http.Response, error) {
 	path := fmt.Sprintf("zones/%s", z.Zone)
 
 	req, err := s.client.NewRequest("POST", path, &z)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	// Update zones fields with data from api(ensure consistent)
 	resp, err := s.client.Do(req, &z)
@@ -123,12 +148,18 @@ func (s *ZonesService) Update(z *dns.Zone) (*http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#zones-delete
 func (s *ZonesService) Delete(zone string) (*http.Response, error) {
+	return s.DeleteWithContext(context.Background(), zone)
+}
+
+// DeleteWithContext is the same as Delete, but takes a context.
+func (s *ZonesService) DeleteWithContext(ctx context.Context, zone string) (*http.Response, error) {
 	path := fmt.Sprintf("zones/%s", zone)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := s.client.Do(req, nil)
 	if err != nil {


### PR DESCRIPTION
This keeps all the exact same functionality of the original methods, but now allows a context to be passed in for better control of the request. This is the preferred way of managing a request, setting a deadline, adding instrumentation, etc. Addresses issue https://github.com/ns1/ns1-go/issues/180.