### PR TITLE
feat: add search api endpoint

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -69,6 +69,8 @@ type Client struct {
 	Notifications *NotificationsService
 	Records       *RecordsService
 	Applications  *ApplicationsService
+	RecordSearch  *RecordSearchService
+	ZoneSearch    *ZoneSearchService
 	Settings      *SettingsService
 	Stats         *StatsService
 	Teams         *TeamsService
@@ -111,6 +113,8 @@ func NewClient(httpClient Doer, options ...func(*Client)) *Client {
 	c.Notifications = (*NotificationsService)(&c.common)
 	c.Records = (*RecordsService)(&c.common)
 	c.Applications = (*ApplicationsService)(&c.common)
+	c.RecordSearch = (*RecordSearchService)(&c.common)
+	c.ZoneSearch = (*ZoneSearchService)(&c.common)
 	c.Settings = (*SettingsService)(&c.common)
 	c.Stats = (*StatsService)(&c.common)
 	c.Teams = (*TeamsService)(&c.common)

--- a/rest/model/dns/search.go
+++ b/rest/model/dns/search.go
@@ -1,0 +1,8 @@
+package dns
+
+type SearchResult struct {
+	Next         string    `json:"next"`
+	Limit        int       `json:"limit"`
+	TotalResults int       `json:"total_results"`
+	Results      []*Record `json:"results"`
+}

--- a/rest/search.go
+++ b/rest/search.go
@@ -32,7 +32,7 @@ func (s *RecordSearchService) Search(params string) (*dns.SearchResult, *http.Re
 type ZoneSearchService service
 
 // Find takes query parameters and returns matching DNS zones.
-func (s *ZoneSearchService) Find(params string) (*dns.SearchResult, *http.Response, error) {
+func (s *ZoneSearchService) Search(params string) (*dns.SearchResult, *http.Response, error) {
 	path := fmt.Sprintf("dns/zone/search?%s", params)
 
 	req, err := s.client.NewRequest("GET", path, nil)

--- a/rest/search.go
+++ b/rest/search.go
@@ -11,7 +11,7 @@ import (
 type RecordSearchService service
 
 // Find takes query parameters and returns matching DNS records.
-func (s *RecordSearchService) Find(params string) (*dns.SearchResult, *http.Response, error) {
+func (s *RecordSearchService) Search(params string) (*dns.SearchResult, *http.Response, error) {
 	path := fmt.Sprintf("dns/record/search?%s", params)
 
 	req, err := s.client.NewRequest("GET", path, nil)

--- a/rest/search.go
+++ b/rest/search.go
@@ -1,0 +1,50 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+// RecordSearchService handles 'dns/record/search' endpoint.
+type RecordSearchService service
+
+// Find takes query parameters and returns matching DNS records.
+func (s *RecordSearchService) Find(params string) (*dns.SearchResult, *http.Response, error) {
+	path := fmt.Sprintf("dns/record/search?%s", params)
+
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var r dns.SearchResult
+	resp, err := s.client.Do(req, &r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &r, resp, nil
+}
+
+// ZoneSearchService handles 'dns/zone/search' endpoint.
+type ZoneSearchService service
+
+// Find takes query parameters and returns matching DNS zones.
+func (s *ZoneSearchService) Find(params string) (*dns.SearchResult, *http.Response, error) {
+	path := fmt.Sprintf("dns/zone/search?%s", params)
+
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var r dns.SearchResult
+	resp, err := s.client.Do(req, &r)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &r, resp, nil
+}


### PR DESCRIPTION
Hello,

I would add the search api endpoint, it could be useful for [terraform-provider-ns1](https://github.com/ns1-terraform/terraform-provider-ns1) to perform some additional validations.

It should resolved the issue https://github.com/ns1/ns1-go/issues/152