### PR TITLE
feat: allow empty tags in record/zone dns model

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -30,10 +30,10 @@ type Record struct {
 	Regions data.Regions `json:"regions,omitempty"`
 
 	// Contains the key/value tag information associated to the record
-	Tags map[string]string `json:"tags,omitempty"` // Only relevant for DDI
+	Tags map[string]string `json:"tags"` // Only relevant for DDI
 
 	// List of tag key names that should not inherit from the parent zone
-	BlockedTags []string `json:"blocked_tags,omitempty"` //Only relevant for DDI
+	BlockedTags []string `json:"blocked_tags"` //Only relevant for DDI
 
 	// Read-only fields
 	LocalTags []string `json:"local_tags,omitempty"` // Only relevant for DDI

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -48,7 +48,7 @@ type Zone struct {
 	DNSSEC *bool `json:"dnssec,omitempty"`
 
 	// Contains the key/value tag information associated to the zone
-	Tags map[string]string `json:"tags,omitempty"` // Only relevant for DDI
+	Tags map[string]string `json:"tags"` // Only relevant for DDI
 }
 
 func (z Zone) String() string {


### PR DESCRIPTION
Hello,

In order to add the support of tags in `ns1_zone` and `ns1_record` of the [terraform-provider-ns1](https://github.com/ns1-terraform/terraform-provider-ns1), we need to allow setting empty tags in the record and zone dns model. See https://github.com/ns1-terraform/terraform-provider-ns1/pull/279

Could you have a review please ? 