### PR TITLE
omit empty filters in record endpoints

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -25,7 +25,7 @@ type Record struct {
 	// Answers must all be of the same type as the record.
 	Answers []*Answer `json:"answers"`
 	// The records' filter chain.
-	Filters []*filter.Filter `json:"filters"`
+	Filters []*filter.Filter `json:"filters,omitempty"`
 	// The records' regions.
 	Regions data.Regions `json:"regions,omitempty"`
 
@@ -39,7 +39,8 @@ type Record struct {
 	LocalTags []string `json:"local_tags,omitempty"` // Only relevant for DDI
 }
 
-func (r Record) String() string {
+// String returns the domain rtype in string format of record
+func (r *Record) String() string {
 	return fmt.Sprintf("%s %s", r.Domain, r.Type)
 }
 

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -18,7 +18,7 @@ var marshalRecordCases = []struct {
 		"marshalCAARecord",
 		NewRecord("example.com", "caa.example.com", "CAA"),
 		[]*Answer{NewCAAAnswer(0, "issue", "letsencrypt.org")},
-		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}],"filters":[]}`),
+		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}]}`),
 	},
 	{
 		"marshalURLFWDRecord",
@@ -27,7 +27,7 @@ var marshalRecordCases = []struct {
 			NewURLFWDAnswer("/net", "https://example.net", 301, 1, 1),
 			NewURLFWDAnswer("/org", "https://example.org", 302, 2, 0),
 		},
-		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD","filters":[]}`),
+		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD"}`),
 	},
 }
 
@@ -60,19 +60,19 @@ func TestMarshalRecordsOverrideTTL(t *testing.T) {
 			"marshalOverrideTTLNil",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			nil,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[]}`),
 		},
 		{
 			"marshalOverrideTTLTrue",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			&trueb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"answers":[],"filters":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"answers":[]}`),
 		},
 		{
 			"marshalOverrideTTLFalse",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			&falseb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"answers":[],"filters":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"answers":[]}`),
 		},
 	}
 	for _, tt := range marshalALIASRecordCases {

--- a/rest/record.go
+++ b/rest/record.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/filter"
 )
 
 // RecordsService handles 'zones/ZONE/DOMAIN/TYPE' endpoint.
@@ -32,6 +33,10 @@ func (s *RecordsService) Get(zone, domain, t string) (*dns.Record, *http.Respons
 			}
 		}
 		return nil, resp, err
+	}
+
+	if r.Filters == nil {
+		r.Filters = make([]*filter.Filter, 0)
 	}
 
 	return &r, resp, nil


### PR DESCRIPTION
This will omit empty filters while marshaling json object for `Record` 