### PR TITLE
add consistent casing for struct tag + tests

### DIFF
--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -57,7 +57,7 @@ func (z Zone) String() string {
 
 // ZoneRecord wraps Zone's "records" attribute
 type ZoneRecord struct {
-	Domain   string      `json:"Domain,omitempty"`
+	Domain   string      `json:"domain,omitempty"`
 	ID       string      `json:"id,omitempty"`
 	Link     string      `json:"link,omitempty"`
 	ShortAns []string    `json:"short_answers,omitempty"`

--- a/rest/model/dns/zone_test.go
+++ b/rest/model/dns/zone_test.go
@@ -12,7 +12,7 @@ import (
 func TestUnmarshalZoneRecords(t *testing.T) {
 	d := []byte(`[
     {
-      "domain": "foo.test.zone",
+      "Domain": "foo.test.zone",
       "short_answers": [
         "1.2.3.4"
       ],


### PR DESCRIPTION
Closes #141

adds consistent casing for struct tag + tests