### PR TITLE
Updating some Exported Names to be idiomatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.7.6 (April 28, 2023)
+BUG FIXES:
+
+* **Breaking** Various name changes to be more idiomatic 
+    *  `DNSView`        -> `View`
+    *  `PulsarJob`      -> `Job`
+    *  `Created_at`     -> `CreatedAt`
+    *  `Updated_at`     -> `UpdatedAt`
+    *  `Read_acls`      -> `ReadACLs`
+    *  `Update_acls`    -> `UpdateACLs`
+    *  `Qps`            -> `QPS`
+    *  `URL_Path`       -> `URLPath`
+    *  `Http`           -> `HTTP`
+    *  `Https`          -> `HTTPS`
+    *  `Override_TTL`   -> `OverrideTTL`
+* Sanitized user input before logging
+
 ## 2.7.5 (March 13, 2023)
 BUG FIXES:
 

--- a/mockns1/dns_view.go
+++ b/mockns1/dns_view.go
@@ -11,7 +11,7 @@ import (
 // function
 func (s *Service) AddDNSViewListTestCase(
 	requestHeaders, responseHeaders http.Header,
-	response []*dns.DNSView,
+	response []*dns.View,
 ) error {
 	return s.AddTestCase(
 		http.MethodGet, "views", http.StatusOK, requestHeaders,
@@ -24,7 +24,7 @@ func (s *Service) AddDNSViewListTestCase(
 func (s *Service) AddDNSViewGetTestCase(
 	viewName string,
 	requestHeaders, responseHeaders http.Header,
-	response *dns.DNSView,
+	response *dns.View,
 ) error {
 	return s.AddTestCase(
 		http.MethodGet, fmt.Sprintf("views/%s", viewName), http.StatusOK, requestHeaders,
@@ -36,7 +36,7 @@ func (s *Service) AddDNSViewGetTestCase(
 // function
 func (s *Service) AddDNSViewCreateTestCase(
 	requestHeaders, responseHeaders http.Header,
-	dnsView, response *dns.DNSView,
+	dnsView, response *dns.View,
 ) error {
 	return s.AddTestCase(
 		http.MethodPut, fmt.Sprintf("views/%s", dnsView.Name), http.StatusOK, requestHeaders,
@@ -48,7 +48,7 @@ func (s *Service) AddDNSViewCreateTestCase(
 // function
 func (s *Service) AddDNSViewUpdateTestCase(
 	requestHeaders, responseHeaders http.Header,
-	dnsView, response *dns.DNSView,
+	dnsView, response *dns.View,
 ) error {
 	return s.AddTestCase(
 		http.MethodPost, fmt.Sprintf("views/%s", dnsView.Name), http.StatusOK, requestHeaders,

--- a/mockns1/pulsar_job.go
+++ b/mockns1/pulsar_job.go
@@ -12,7 +12,7 @@ import (
 func (s *Service) AddPulsarJobListTestCase(
 	appid string,
 	requestHeaders, responseHeaders http.Header,
-	response []*pulsar.PulsarJob,
+	response []*pulsar.Job,
 ) error {
 	return s.AddTestCase(
 		http.MethodGet, fmt.Sprintf("/pulsar/apps/%s/jobs", appid), http.StatusOK, requestHeaders,
@@ -25,7 +25,7 @@ func (s *Service) AddPulsarJobListTestCase(
 func (s *Service) AddPulsarJobGetTestCase(
 	appid, jobid string,
 	requestHeaders, responseHeaders http.Header,
-	response *pulsar.PulsarJob,
+	response *pulsar.Job,
 ) error {
 	return s.AddTestCase(
 		http.MethodGet, fmt.Sprintf("/pulsar/apps/%s/jobs/%s", appid, jobid), http.StatusOK, requestHeaders,
@@ -37,7 +37,7 @@ func (s *Service) AddPulsarJobGetTestCase(
 // function
 func (s *Service) AddPulsarJobCreateTestCase(
 	requestHeaders, responseHeaders http.Header,
-	pulsarJob, response *pulsar.PulsarJob,
+	pulsarJob, response *pulsar.Job,
 ) error {
 	return s.AddTestCase(
 		http.MethodPut, fmt.Sprintf("pulsar/apps/%s/jobs", pulsarJob.AppID), http.StatusOK, requestHeaders,
@@ -49,7 +49,7 @@ func (s *Service) AddPulsarJobCreateTestCase(
 // function
 func (s *Service) AddPulsarJobUpdateTestCase(
 	requestHeaders, responseHeaders http.Header,
-	pulsarJob, response *pulsar.PulsarJob,
+	pulsarJob, response *pulsar.Job,
 ) error {
 	return s.AddTestCase(
 		http.MethodPost, fmt.Sprintf("pulsar/apps/%s/jobs/%s", pulsarJob.AppID, pulsarJob.JobID), http.StatusOK, requestHeaders,
@@ -61,7 +61,7 @@ func (s *Service) AddPulsarJobUpdateTestCase(
 // function
 func (s *Service) AddPulsarJobDeleteTestCase(
 	requestHeaders, responseHeaders http.Header,
-	pulsarJob, response *pulsar.PulsarJob,
+	pulsarJob, response *pulsar.Job,
 ) error {
 	return s.AddTestCase(
 		http.MethodDelete, fmt.Sprintf("pulsar/apps/%s/jobs/%s", pulsarJob.AppID, pulsarJob.JobID), http.StatusOK, requestHeaders,

--- a/rest/client.go
+++ b/rest/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	clientVersion = "2.7.5"
+	clientVersion = "2.7.6"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true

--- a/rest/dns_view.go
+++ b/rest/dns_view.go
@@ -14,13 +14,13 @@ type DNSViewService service
 // List returns all DNS Views
 //
 // NS1 API docs: https://ns1.com/api#getlist-all-dns-views
-func (s *DNSViewService) List() ([]*dns.DNSView, *http.Response, error) {
+func (s *DNSViewService) List() ([]*dns.View, *http.Response, error) {
 	req, err := s.client.NewRequest("GET", "views", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var vl []*dns.DNSView
+	var vl []*dns.View
 	resp, err := s.client.Do(req, &vl)
 	if err != nil {
 		return nil, resp, err
@@ -33,7 +33,7 @@ func (s *DNSViewService) List() ([]*dns.DNSView, *http.Response, error) {
 //
 // The given DNSView must have at least the name
 // NS1 API docs: https://ns1.com/api#putcreate-a-dns-view
-func (s *DNSViewService) Create(v *dns.DNSView) (*http.Response, error) {
+func (s *DNSViewService) Create(v *dns.View) (*http.Response, error) {
 	req, err := s.client.NewRequest("PUT", fmt.Sprintf("/v1/views/%s", v.Name), v)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func (s *DNSViewService) Create(v *dns.DNSView) (*http.Response, error) {
 // Get takes a DNS view name and returns DNSView struct.
 //
 // NS1 API docs: https://ns1.com/api#getview-dns-view-details
-func (s *DNSViewService) Get(viewName string) (*dns.DNSView, *http.Response, error) {
+func (s *DNSViewService) Get(viewName string) (*dns.View, *http.Response, error) {
 	path := fmt.Sprintf("views/%s", viewName)
 
 	req, err := s.client.NewRequest("GET", path, nil)
@@ -65,7 +65,7 @@ func (s *DNSViewService) Get(viewName string) (*dns.DNSView, *http.Response, err
 		return nil, nil, err
 	}
 
-	var v dns.DNSView
+	var v dns.View
 	resp, err := s.client.Do(req, &v)
 	if err != nil {
 		switch errType := err.(type) {
@@ -83,7 +83,7 @@ func (s *DNSViewService) Get(viewName string) (*dns.DNSView, *http.Response, err
 // Update takes a *dns.DNSView and updates the DNS view with same name on NS1.
 //
 // NS1 API docs: https://ns1.com/api#postedit-a-dns-view
-func (s *DNSViewService) Update(v *dns.DNSView) (*http.Response, error) {
+func (s *DNSViewService) Update(v *dns.View) (*http.Response, error) {
 	path := fmt.Sprintf("views/%s", v.Name)
 
 	req, err := s.client.NewRequest("POST", path, &v)

--- a/rest/dns_view_test.go
+++ b/rest/dns_view_test.go
@@ -26,7 +26,7 @@ func TestDNSView(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			defer mock.ClearTestCases()
 
-			views := []*dns.DNSView{
+			views := []*dns.View{
 				{
 					Name:       "DNSView1",
 					Preference: 1,
@@ -276,15 +276,15 @@ func TestDNSView(t *testing.T) {
 }
 
 var (
-	myView = dns.DNSView{
-		Name:       "myView",
-		Created_at: 123456789,
-		Updated_at: 987654321,
-		Read_acls: []string{
+	myView = dns.View{
+		Name:      "myView",
+		CreatedAt: 123456789,
+		UpdatedAt: 987654321,
+		ReadACLs: []string{
 			"myACLS1",
 			"myACLS2",
 		},
-		Update_acls: []string{
+		UpdateACLs: []string{
 			"myACLS1",
 			"myACLS2",
 			"myACLS3",

--- a/rest/model/dns/dns_view.go
+++ b/rest/model/dns/dns_view.go
@@ -1,20 +1,20 @@
 package dns
 
-// DNSView wraps an NS1 views/ resource
-type DNSView struct {
-	Name        string   `json:"name,omitempty"`
-	Created_at  int      `json:"created_at,omitempty"`
-	Updated_at  int      `json:"updated_at,omitempty"`
-	Read_acls   []string `json:"read_acls"`
-	Update_acls []string `json:"update_acls"`
-	Zones       []string `json:"zones"`
-	Networks    []int    `json:"networks"`
-	Preference  int      `json:"preference,omitempty"`
+// View wraps an NS1 views/ resource
+type View struct {
+	Name       string   `json:"name,omitempty"`
+	CreatedAt  int      `json:"created_at,omitempty"`
+	UpdatedAt  int      `json:"updated_at,omitempty"`
+	ReadACLs   []string `json:"read_acls"`
+	UpdateACLs []string `json:"update_acls"`
+	Zones      []string `json:"zones"`
+	Networks   []int    `json:"networks"`
+	Preference int      `json:"preference,omitempty"`
 }
 
-// NewDNSView takes a viewName and creates a *DNSView
-func NewDNSView(viewName string) *DNSView {
-	return &DNSView{
+// NewView takes a viewName and creates a *DNSView
+func NewView(viewName string) *View {
+	return &View{
 		Name: viewName,
 	}
 }

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -19,7 +19,7 @@ type Record struct {
 	Type            string `json:"type"`
 	Link            string `json:"link,omitempty"`
 	TTL             int    `json:"ttl,omitempty"`
-	Override_TTL    *bool  `json:"override_ttl,omitempty"`
+	OverrideTTL     *bool  `json:"override_ttl,omitempty"`
 	UseClientSubnet *bool  `json:"use_client_subnet,omitempty"`
 
 	// Answers must all be of the same type as the record.

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -77,7 +77,7 @@ func TestMarshalRecordsOverrideTTL(t *testing.T) {
 	}
 	for _, tt := range marshalALIASRecordCases {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.record.Override_TTL = tt.overrideTTL
+			tt.record.OverrideTTL = tt.overrideTTL
 			result, err := json.Marshal(tt.record)
 			if err != nil {
 				t.Error(err)

--- a/rest/model/pulsar/application.go
+++ b/rest/model/pulsar/application.go
@@ -12,8 +12,8 @@ type Application struct {
 
 // DefaultConfig contains configuration parameters for application
 type DefaultConfig struct {
-	Http                 bool `json:"http"`
-	Https                bool `json:"https"`
+	HTTP                 bool `json:"http"`
+	HTTPS                bool `json:"https"`
 	RequestTimeoutMillis int  `json:"request_timeout_millis"`
 	JobTimeoutMillis     int  `json:"job_timeout_millis"`
 	UseXhr               bool `json:"use_xhr"`

--- a/rest/model/pulsar/pulsar_job.go
+++ b/rest/model/pulsar/pulsar_job.go
@@ -1,7 +1,7 @@
 package pulsar
 
-// PulsarJob wraps an NS1 pulsar/apps/{appid}/jobs/{jobid} resource
-type PulsarJob struct {
+// Job wraps an NS1 pulsar/apps/{appid}/jobs/{jobid} resource
+type Job struct {
 	Customer  int        `json:"customer,omitempty"`
 	TypeID    string     `json:"typeid"`
 	Name      string     `json:"name"`
@@ -16,9 +16,9 @@ type PulsarJob struct {
 // JobConfig config parameter struct
 type JobConfig struct {
 	Host                 *string             `json:"host"`
-	URL_Path             *string             `json:"url_path"`
-	Http                 *bool               `json:"http,omitempty"`
-	Https                *bool               `json:"https,omitempty"`
+	URLPath              *string             `json:"url_path"`
+	HTTP                 *bool               `json:"http,omitempty"`
+	HTTPS                *bool               `json:"https,omitempty"`
 	RequestTimeoutMillis *int                `json:"request_timeout_millis,omitempty"`
 	JobTimeoutMillis     *int                `json:"job_timeout_millis,omitempty"`
 	UseXHR               *bool               `json:"use_xhr,omitempty"`
@@ -40,22 +40,22 @@ type Weights struct {
 	Maximize     bool    `json:"maximize"`
 }
 
-// NewJSPulsarJob takes a name, appid, host and urlPath and creates a JavaScript Pulsar job (type *PulsarJob)
-func NewJSPulsarJob(name string, appid string, host string, urlPath string) *PulsarJob {
-	return &PulsarJob{
+// NewJSPulsarJob takes a name, appid, host and urlPath and creates a JavaScript Pulsar job (type *Job)
+func NewJSPulsarJob(name string, appid string, host string, urlPath string) *Job {
+	return &Job{
 		Name:   name,
 		TypeID: "latency",
 		AppID:  appid,
 		Config: &JobConfig{
-			Host:     &host,
-			URL_Path: &urlPath,
+			Host:    &host,
+			URLPath: &urlPath,
 		},
 	}
 }
 
 // NewBBPulsarJob takes a name and appid and creates a Bulk Beacon Pulsar job (type *PulsarJob)
-func NewBBPulsarJob(name string, appid string) *PulsarJob {
-	return &PulsarJob{
+func NewBBPulsarJob(name string, appid string) *Job {
+	return &Job{
 		Name:   name,
 		TypeID: "custom",
 		AppID:  appid,

--- a/rest/model/pulsar/pulsar_job_test.go
+++ b/rest/model/pulsar/pulsar_job_test.go
@@ -23,5 +23,5 @@ func TestNewJSPulsarJob(t *testing.T) {
 	assert.Equal(t, "myJSPulsarJob", j.Name, "Wrong name")
 	assert.Equal(t, "myAppId", j.AppID, "Wrong appid")
 	assert.Equal(t, &myHost, j.Config.Host, "Wrong host")
-	assert.Equal(t, &myURLPath, j.Config.URL_Path, "Wrong url_path")
+	assert.Equal(t, &myURLPath, j.Config.URLPath, "Wrong url_path")
 }

--- a/rest/pulsar_job.go
+++ b/rest/pulsar_job.go
@@ -14,14 +14,14 @@ type PulsarJobsService service
 // List takes an Application ID and returns all Jobs inside said Application.
 //
 // NS1 API docs: https://ns1.com/api/#getlist-jobs-within-an-app
-func (s *PulsarJobsService) List(appID string) ([]*pulsar.PulsarJob, *http.Response, error) {
+func (s *PulsarJobsService) List(appID string) ([]*pulsar.Job, *http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs", appID)
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	jl := []*pulsar.PulsarJob{}
+	jl := []*pulsar.Job{}
 	var resp *http.Response
 	resp, err = s.client.Do(req, &jl)
 	if err != nil {
@@ -40,7 +40,7 @@ func (s *PulsarJobsService) List(appID string) ([]*pulsar.PulsarJob, *http.Respo
 // Get takes an Application ID and Job Id and returns full configuration for a pulsar Job.
 //
 // NS1 API docs: https://ns1.com/api/#getview-job-details
-func (s *PulsarJobsService) Get(appID string, jobID string) (*pulsar.PulsarJob, *http.Response, error) {
+func (s *PulsarJobsService) Get(appID string, jobID string) (*pulsar.Job, *http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs/%s", appID, jobID)
 
 	req, err := s.client.NewRequest("GET", path, nil)
@@ -48,7 +48,7 @@ func (s *PulsarJobsService) Get(appID string, jobID string) (*pulsar.PulsarJob, 
 		return nil, nil, err
 	}
 
-	var job pulsar.PulsarJob
+	var job pulsar.Job
 
 	resp, err := s.client.Do(req, &job)
 	if err != nil {
@@ -72,7 +72,7 @@ func (s *PulsarJobsService) Get(appID string, jobID string) (*pulsar.PulsarJob, 
 // Create takes a *PulsarJob and an AppId and creates a new Pulsar Job in the specified Application with the specific name, typeid, host and url_path.
 //
 // NS1 API docs: https://ns1.com/api/#putcreate-a-pulsar-job
-func (s *PulsarJobsService) Create(j *pulsar.PulsarJob) (*http.Response, error) {
+func (s *PulsarJobsService) Create(j *pulsar.Job) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs", j.AppID)
 
 	req, err := s.client.NewRequest("PUT", path, j)
@@ -99,7 +99,7 @@ func (s *PulsarJobsService) Create(j *pulsar.PulsarJob) (*http.Response, error) 
 //
 // Only the fields to be updated are required in the given job.
 // NS1 API docs: https://ns1.com/api/#postmodify-a-pulsar-job
-func (s *PulsarJobsService) Update(j *pulsar.PulsarJob) (*http.Response, error) {
+func (s *PulsarJobsService) Update(j *pulsar.Job) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs/%s", j.AppID, j.JobID)
 
 	req, err := s.client.NewRequest("POST", path, j)
@@ -129,7 +129,7 @@ func (s *PulsarJobsService) Update(j *pulsar.PulsarJob) (*http.Response, error) 
 // Delete takes a appId and jobId and removes an existing Pulsar job .
 //
 // NS1 API docs: https://ns1.com/api/#deletedelete-a-pulsar-job
-func (s *PulsarJobsService) Delete(pulsarJob *pulsar.PulsarJob) (*http.Response, error) {
+func (s *PulsarJobsService) Delete(pulsarJob *pulsar.Job) (*http.Response, error) {
 	path := fmt.Sprintf("pulsar/apps/%s/jobs/%s", pulsarJob.AppID, pulsarJob.JobID)
 
 	req, err := s.client.NewRequest("DELETE", path, nil)

--- a/rest/pulsar_job_test.go
+++ b/rest/pulsar_job_test.go
@@ -31,13 +31,13 @@ func TestPulsarJob(t *testing.T) {
 				myURLPATH = "/myURLPath1"
 			)
 
-			pulsarJobs := []*pulsar.PulsarJob{
+			pulsarJobs := []*pulsar.Job{
 				{
 					Name:   "PulsarJob1",
 					TypeID: "latency",
 					Config: &pulsar.JobConfig{
-						Host:     &myhost,
-						URL_Path: &myURLPATH,
+						Host:    &myhost,
+						URLPath: &myURLPATH,
 					},
 				},
 				{
@@ -58,7 +58,7 @@ func TestPulsarJob(t *testing.T) {
 				require.Equal(t, pulsarJobs[i].TypeID, respPulsarJobs[i].TypeID, i)
 				if respPulsarJobs[i].TypeID == "latency" {
 					require.Equal(t, pulsarJobs[i].Config.Host, respPulsarJobs[i].Config.Host, i)
-					require.Equal(t, pulsarJobs[i].Config.URL_Path, respPulsarJobs[i].Config.URL_Path, i)
+					require.Equal(t, pulsarJobs[i].Config.URLPath, respPulsarJobs[i].Config.URLPath, i)
 				}
 			}
 		})
@@ -114,7 +114,7 @@ func TestPulsarJob(t *testing.T) {
 				testStaticValues   = true
 			)
 
-			pulsarJob := &pulsar.PulsarJob{
+			pulsarJob := &pulsar.Job{
 				Customer:  2156,
 				TypeID:    "latency",
 				Name:      "myPulsarJob",
@@ -125,9 +125,9 @@ func TestPulsarJob(t *testing.T) {
 				Shared:    true,
 				Config: &pulsar.JobConfig{
 					Host:                 &testHost,
-					URL_Path:             &testUrlPath,
-					Http:                 &testHttp,
-					Https:                &testHttps,
+					URLPath:              &testUrlPath,
+					HTTP:                 &testHttp,
+					HTTPS:                &testHttps,
 					RequestTimeoutMillis: &testRequestTimeout,
 					JobTimeoutMillis:     &testJobTimeout,
 					UseXHR:               &testXHR,
@@ -210,7 +210,7 @@ func TestPulsarJob(t *testing.T) {
 	})
 
 	t.Run("Create", func(t *testing.T) {
-		pulsarJob := &pulsar.PulsarJob{
+		pulsarJob := &pulsar.Job{
 			Name:   "myPulsarJob",
 			TypeID: "latency",
 			AppID:  myAppID,
@@ -257,7 +257,7 @@ func TestPulsarJob(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		pulsarJob := &pulsar.PulsarJob{
+		pulsarJob := &pulsar.Job{
 			Name:   "updatedPulsarJob",
 			TypeID: "custom",
 			AppID:  myAppID,
@@ -321,7 +321,7 @@ func TestPulsarJob(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		pulsarJob := &pulsar.PulsarJob{
+		pulsarJob := &pulsar.Job{
 			Name:   "myPulsarJob",
 			TypeID: "custom",
 			AppID:  myAppID,

--- a/rest/stat.go
+++ b/rest/stat.go
@@ -46,7 +46,7 @@ func (s *StatsService) getQPS(path string) (float32, *http.Response, error) {
 			Qps float32
 		}
 		*/
-		Qps float32
+		QPS float32
 	}
 	resp, err := s.client.Do(req, &value)
 
@@ -62,5 +62,5 @@ func (s *StatsService) getQPS(path string) (float32, *http.Response, error) {
 		}
 		return 0, resp, err
 	}
-	return value.Qps, resp, nil
+	return value.QPS, resp, nil
 }


### PR DESCRIPTION
This PR clears up the remaining, golint/CodeQl warnings and pushes a new version.

BUG FIXES:

* **Breaking** Various name changes to be more idiomatic 
    *  `DNSView`        -> `View`
    *  `PulsarJob`      -> `Job`
    *  `Created_at`     -> `CreatedAt`
    *  `Updated_at`     -> `UpdatedAt`
    *  `Read_acls`      -> `ReadACLs`
    *  `Update_acls`    -> `UpdateACLs`
    *  `Qps`            -> `QPS`
    *  `URL_Path`       -> `URLPath`
    *  `Http`           -> `HTTP`
    *  `Https`          -> `HTTPS`
    *  `Override_TTL`   -> `OverrideTTL`
* Sanitized user input before logging