### PR TITLE
Add means to get monitoring/regions

### DIFF
--- a/rest/model/monitor/region.go
+++ b/rest/model/monitor/region.go
@@ -1,0 +1,13 @@
+package monitor
+
+type Region struct {
+	// The region code to use when provisioning.
+	Code string `json:"code"`
+
+	// The display name for the region.
+	Name string `json:"name"`
+
+	// The list of all subnets from which monitoring traffic is generated
+	// in that region.
+	Subnets []string `json:"subnets"`
+}

--- a/rest/monitor_regions.go
+++ b/rest/monitor_regions.go
@@ -1,0 +1,28 @@
+package rest
+
+import (
+	"net/http"
+
+	"gopkg.in/ns1/ns1-go.v2/rest/model/monitor"
+)
+
+// RegionsService handles 'monitoring/regions' endpoint.
+type RegionsService service
+
+// List returns all monitoring jobs for the account.
+//
+// NS1 API docs: https://ns1.com/api?docId=2247
+func (s *RegionsService) List() ([]*monitor.Region, *http.Response, error) {
+	req, err := s.client.NewRequest("GET", "monitoring/regions", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mrl := []*monitor.Region{}
+	resp, err := s.client.Do(req, &mrl)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return mrl, resp, nil
+}

--- a/rest/monitor_regions.go
+++ b/rest/monitor_regions.go
@@ -9,7 +9,7 @@ import (
 // RegionsService handles 'monitoring/regions' endpoint.
 type RegionsService service
 
-// List returns all monitoring jobs for the account.
+// List returns all available monitoring regions for the account.
 //
 // NS1 API docs: https://ns1.com/api?docId=2247
 func (s *RegionsService) List() ([]*monitor.Region, *http.Response, error) {


### PR DESCRIPTION
I would like to be able to access the monitoring/regions list from the Terraform provider (for which we're presently just using an http data resource), and so chose to add this to the API. I've based this somewhat on other monitor_ functions as I'm not the world's most confident Go coder.