### PR TITLE
Remove ID field from monitor job create path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.8 (July 27th, 2023)
+BUG FIXES:
+
+* Removes `id` field from monitoring job creation URL
+
 ## 2.7.6 (April 28, 2023)
 BUG FIXES:
 

--- a/rest/client.go
+++ b/rest/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	clientVersion = "2.7.7"
+	clientVersion = "2.7.8"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true

--- a/rest/monitor_job.go
+++ b/rest/monitor_job.go
@@ -53,7 +53,7 @@ func (s *JobsService) Get(id string) (*monitor.Job, *http.Response, error) {
 //
 // NS1 API docs: https://ns1.com/api/#jobs-put
 func (s *JobsService) Create(mj *monitor.Job) (*http.Response, error) {
-	path := fmt.Sprintf("%s/%s", "monitoring/jobs", mj.ID)
+	path := fmt.Sprintf("%s", "monitoring/jobs")
 
 	req, err := s.client.NewRequest("PUT", path, &mj)
 	if err != nil {


### PR DESCRIPTION
This PR removes the ID field from the URL for monitor creation.