### PR TITLE
INBOX-2625 - Remove omitempty for filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.11 (October 5th, 2023)
+
+BUG FIXES:
+
+* Remove `omitempty` from filters to allow removal of filters
+
 ## 2.7.10 (September 29th, 2023)
 
 FEATURES:

--- a/rest/client.go
+++ b/rest/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	clientVersion = "2.7.10"
+	clientVersion = "2.7.11"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true

--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -26,7 +26,7 @@ type Record struct {
 	// Answers must all be of the same type as the record.
 	Answers []*Answer `json:"answers"`
 	// The records' filter chain.
-	Filters []*filter.Filter `json:"filters,omitempty"`
+	Filters []*filter.Filter `json:"filters"`
 	// The records' regions.
 	Regions data.Regions `json:"regions,omitempty"`
 

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -18,7 +18,7 @@ var marshalRecordCases = []struct {
 		"marshalCAARecord",
 		NewRecord("example.com", "caa.example.com", "CAA"),
 		[]*Answer{NewCAAAnswer(0, "issue", "letsencrypt.org")},
-		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}]}`),
+		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}],"filters":[]}`),
 	},
 	{
 		"marshalURLFWDRecord",
@@ -27,7 +27,7 @@ var marshalRecordCases = []struct {
 			NewURLFWDAnswer("/net", "https://example.net", 301, 1, 1),
 			NewURLFWDAnswer("/org", "https://example.org", 302, 2, 0),
 		},
-		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD"}`),
+		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD","filters":[]}`),
 	},
 }
 
@@ -60,19 +60,19 @@ func TestMarshalRecordsOverrideTTL(t *testing.T) {
 			"marshalOverrideTTLNil",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			nil,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideTTLTrue",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			&trueb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"answers":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideTTLFalse",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			&falseb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"answers":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"answers":[],"filters":[]}`),
 		},
 	}
 	for _, tt := range marshalALIASRecordCases {
@@ -104,21 +104,21 @@ func TestMarshalRecordsOverrideAddressRecords(t *testing.T) {
 			NewRecord("example.com", "example.com", "ALIAS"),
 			nil,
 			nil,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideAddressRecordsTrue",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			&trueb,
 			&trueb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"override_address_records":true,"answers":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"override_address_records":true,"answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideAddressRecordsFalse",
 			NewRecord("example.com", "example.com", "ALIAS"),
 			&falseb,
 			&falseb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"override_address_records":false,"answers":[]}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"override_address_records":false,"answers":[],"filters":[]}`),
 		},
 	}
 	for _, tt := range marshalALIASRecordCases {

--- a/rest/record.go
+++ b/rest/record.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
-	"gopkg.in/ns1/ns1-go.v2/rest/model/filter"
 )
 
 // RecordsService handles 'zones/ZONE/DOMAIN/TYPE' endpoint.
@@ -33,10 +32,6 @@ func (s *RecordsService) Get(zone, domain, t string) (*dns.Record, *http.Respons
 			}
 		}
 		return nil, resp, err
-	}
-
-	if r.Filters == nil {
-		r.Filters = make([]*filter.Filter, 0)
 	}
 
 	return &r, resp, nil


### PR DESCRIPTION
We need empty filters in order to remove filters, if we omit then terraform cannot remove all filters from records.