### PR TITLE
INBOX-2702: Fixes #224 by omitting empty tags

### DIFF
--- a/rest/model/dns/record.go
+++ b/rest/model/dns/record.go
@@ -31,10 +31,10 @@ type Record struct {
 	Regions data.Regions `json:"regions,omitempty"`
 
 	// Contains the key/value tag information associated to the record
-	Tags map[string]string `json:"tags"` // Only relevant for DDI
+	Tags map[string]string `json:"tags,omitempty"` // Only relevant for DDI
 
 	// List of tag key names that should not inherit from the parent zone
-	BlockedTags []string `json:"blocked_tags"` //Only relevant for DDI
+	BlockedTags []string `json:"blocked_tags,omitempty"` //Only relevant for DDI
 
 	// Read-only fields
 	LocalTags []string `json:"local_tags,omitempty"` // Only relevant for DDI

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -18,7 +18,7 @@ var marshalRecordCases = []struct {
 		"marshalCAARecord",
 		NewRecord("example.com", "caa.example.com", "CAA", nil, nil),
 		[]*Answer{NewCAAAnswer(0, "issue", "letsencrypt.org")},
-		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}],"filters":[],"tags":null,"blocked_tags":null}`),
+		[]byte(`{"meta":{},"zone":"example.com","domain":"caa.example.com","type":"CAA","answers":[{"meta":{},"answer":["0","issue","letsencrypt.org"]}],"filters":[]}`),
 	},
 	{
 		"marshalURLFWDRecord",
@@ -27,7 +27,7 @@ var marshalRecordCases = []struct {
 			NewURLFWDAnswer("/net", "https://example.net", 301, 1, 1),
 			NewURLFWDAnswer("/org", "https://example.org", 302, 2, 0),
 		},
-		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD","filters":[],"tags":null,"blocked_tags":null}`),
+		[]byte(`{"answers":[{"answer":["/net","https://example.net",301,1,1],"meta":{}},{"answer":["/org","https://example.org",302,2,0],"meta":{}}],"meta":{},"zone":"example.com","domain":"fwd.example.com","type":"URLFWD","filters":[]}`),
 	},
 }
 
@@ -60,19 +60,19 @@ func TestMarshalRecordsOverrideTTL(t *testing.T) {
 			"marshalOverrideTTLNil",
 			NewRecord("example.com", "example.com", "ALIAS", nil, nil),
 			nil,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[],"tags":null,"blocked_tags":null}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideTTLTrue",
 			NewRecord("example.com", "example.com", "ALIAS", nil, nil),
 			&trueb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"answers":[],"filters":[],"tags":null,"blocked_tags":null}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideTTLFalse",
 			NewRecord("example.com", "example.com", "ALIAS", nil, nil),
 			&falseb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"answers":[],"filters":[],"tags":null,"blocked_tags":null}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"answers":[],"filters":[]}`),
 		},
 	}
 	for _, tt := range marshalALIASRecordCases {
@@ -104,21 +104,21 @@ func TestMarshalRecordsOverrideAddressRecords(t *testing.T) {
 			NewRecord("example.com", "example.com", "ALIAS", nil, nil),
 			nil,
 			nil,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[],"tags":null,"blocked_tags":null}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideAddressRecordsTrue",
 			NewRecord("example.com", "example.com", "ALIAS", nil, nil),
 			&trueb,
 			&trueb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"override_address_records":true,"answers":[],"filters":[],"tags":null,"blocked_tags":null}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":true,"override_address_records":true,"answers":[],"filters":[]}`),
 		},
 		{
 			"marshalOverrideAddressRecordsFalse",
 			NewRecord("example.com", "example.com", "ALIAS", nil, nil),
 			&falseb,
 			&falseb,
-			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"override_address_records":false,"answers":[],"filters":[],"tags":null,"blocked_tags":null}`),
+			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","override_ttl":false,"override_address_records":false,"answers":[],"filters":[]}`),
 		},
 	}
 	for _, tt := range marshalALIASRecordCases {

--- a/rest/model/dns/record_test.go
+++ b/rest/model/dns/record_test.go
@@ -58,7 +58,7 @@ func TestMarshalRecordsOverrideTTL(t *testing.T) {
 	}{
 		{
 			"marshalOverrideTTLNil",
-			NewRecord("example.com", "example.com", "ALIAS", nil, nil),
+			NewRecord("example.com", "example.com", "ALIAS", make(map[string]string), []string{}),
 			nil,
 			[]byte(`{"meta":{},"zone":"example.com","domain":"example.com","type":"ALIAS","answers":[],"filters":[]}`),
 		},


### PR DESCRIPTION
This PR sets `tags` and `blocked_tags` as `omitempty`, which fixes the issue in #224 on the client side: however, this has a side effect of not allowing to empty out existing tags in an update, because an empty array is omitted just like null is.