### PR TITLE
Release 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.9.1 (April 3rd, 2024)
+
+BUG FIXES:
+
+* Re-add `omitempty` to both `tags` and `blocked_tags` as the limitation in update 2.7.12 has been lifted
+
 ## 2.9.0 (March 7th, 2024)
 
 FEATURES:
@@ -49,7 +55,7 @@ BUG FIXES:
 ## 2.7.6 (April 28, 2023)
 BUG FIXES:
 
-* **Breaking** Various name changes to be more idiomatic 
+* **Breaking** Various name changes to be more idiomatic
     *  `DNSView`        -> `View`
     *  `PulsarJob`      -> `Job`
     *  `Created_at`     -> `CreatedAt`

--- a/rest/client.go
+++ b/rest/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	clientVersion = "2.9.0"
+	clientVersion = "2.9.1"
 
 	defaultEndpoint               = "https://api.nsone.net/v1/"
 	defaultShouldFollowPagination = true


### PR DESCRIPTION
This is to release the recent change to `tags` and `blocked_tags`