### PR TITLE
Add destinations field to Feed

### DIFF
--- a/rest/model/data/feed.go
+++ b/rest/model/data/feed.go
@@ -29,6 +29,8 @@ type Feed struct {
 	Config Config `json:"config,omitempty"`
 	Data   Meta   `json:"data,omitempty"`
 
+	Destinations []Destination `json:"destinations"`
+
 	SourceID string
 }
 


### PR DESCRIPTION
This PR adds the missing "Destinations" field to the "Feed" struct as described in this issue: https://github.com/ns1/ns1-go/issues/239