### PR TITLE
add billing-usage GET request api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 test/test
-rest/_examples/2002_num_queries_account_from_2025-02-01_to_2025-02-28_on_2025-03-25.csv
+rest/_examples/*.csv
 .vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 test/test
+rest/_examples/2002_num_queries_account_from_2025-02-01_to_2025-02-28_on_2025-03-25.csv
+.vscode/launch.json

--- a/mockns1/billing_usage.go
+++ b/mockns1/billing_usage.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	billing_usage "gopkg.in/ns1/ns1-go.v2/rest/model/billing-usage"
+	billingusage "gopkg.in/ns1/ns1-go.v2/rest/model/billingusage"
 )
 
-// Should be identical to rest.billing_usage
+// Should be identical to rest.billingusage
 const billingUsagePath = "../billing-usage/v1/"
 
 // AddBillingUsageQueriesGetTestCase sets up a test case for the api.Client.BillingUsage.GetQueries(int32(from), int32(to))
@@ -16,10 +16,10 @@ func (s *Service) AddBillingUsageQueriesGetTestCase(
 	from int32,
 	to int32,
 	requestHeaders, responseHeaders http.Header,
-	response *billing_usage.Queries,
+	response *billingusage.Queries,
 ) error {
 
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageQueries, from, to)
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billingusage.BillingUsageQueries, from, to)
 	return s.AddTestCase(
 		http.MethodGet, path, http.StatusOK, requestHeaders,
 		responseHeaders, "", response,
@@ -33,7 +33,7 @@ func (s *Service) AddBillingUsageQueriesFailTestCase(
 	requestHeaders, responseHeaders http.Header,
 	responseBody string,
 ) error {
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageQueries, from, to)
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billingusage.BillingUsageQueries, from, to)
 	return s.AddTestCase(
 		method, path, returnStatus,
 		nil, nil, "", responseBody)
@@ -45,10 +45,10 @@ func (s *Service) AddBillingUsageLimitsGetTestCase(
 	from int32,
 	to int32,
 	requestHeaders, responseHeaders http.Header,
-	response *billing_usage.Limits,
+	response *billingusage.Limits,
 ) error {
 
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageLimits, from, to)
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billingusage.BillingUsageLimits, from, to)
 	return s.AddTestCase(
 		http.MethodGet, path, http.StatusOK, requestHeaders,
 		responseHeaders, "", response,
@@ -62,7 +62,7 @@ func (s *Service) AddBillingUsageLimitsFailTestCase(
 	requestHeaders, responseHeaders http.Header,
 	responseBody string,
 ) error {
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageLimits, from, to)
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billingusage.BillingUsageLimits, from, to)
 	return s.AddTestCase(
 		method, path, returnStatus,
 		nil, nil, "", responseBody)
@@ -74,10 +74,10 @@ func (s *Service) AddBillingUsageDecisionsGetTestCase(
 	from int32,
 	to int32,
 	requestHeaders, responseHeaders http.Header,
-	response *billing_usage.TotalUsage,
+	response *billingusage.TotalUsage,
 ) error {
 
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageDecisions, from, to)
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billingusage.BillingUsageDecisions, from, to)
 	return s.AddTestCase(
 		http.MethodGet, path, http.StatusOK, requestHeaders,
 		responseHeaders, "", response,
@@ -91,7 +91,7 @@ func (s *Service) AddBillingUsageDecisionsFailTestCase(
 	requestHeaders, responseHeaders http.Header,
 	responseBody string,
 ) error {
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageDecisions, from, to)
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billingusage.BillingUsageDecisions, from, to)
 	return s.AddTestCase(
 		method, path, returnStatus,
 		nil, nil, "", responseBody)
@@ -101,9 +101,9 @@ func (s *Service) AddBillingUsageDecisionsFailTestCase(
 // function
 func (s *Service) AddBillingUsageMonitorsGetTestCase(
 	requestHeaders, responseHeaders http.Header,
-	response *billing_usage.TotalUsage,
+	response *billingusage.TotalUsage,
 ) error {
-	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageMonitors)
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billingusage.BillingUsageMonitors)
 	return s.AddTestCase(
 		http.MethodGet, path, http.StatusOK, requestHeaders,
 		responseHeaders, "", response,
@@ -117,7 +117,7 @@ func (s *Service) AddBillingUsageMonitorsFailTestCase(
 	requestHeaders, responseHeaders http.Header,
 	responseBody string,
 ) error {
-	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageMonitors)
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billingusage.BillingUsageMonitors)
 	return s.AddTestCase(
 		method, path, returnStatus,
 		nil, nil, "", responseBody)
@@ -127,9 +127,9 @@ func (s *Service) AddBillingUsageMonitorsFailTestCase(
 // function
 func (s *Service) AddBillingUsageFilterChainsGetTestCase(
 	requestHeaders, responseHeaders http.Header,
-	response *billing_usage.TotalUsage,
+	response *billingusage.TotalUsage,
 ) error {
-	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageFilterChains)
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billingusage.BillingUsageFilterChains)
 	return s.AddTestCase(
 		http.MethodGet, path, http.StatusOK, requestHeaders,
 		responseHeaders, "", response,
@@ -143,7 +143,7 @@ func (s *Service) AddBillingUsageFilterChainsFailTestCase(
 	requestHeaders, responseHeaders http.Header,
 	responseBody string,
 ) error {
-	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageFilterChains)
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billingusage.BillingUsageFilterChains)
 	return s.AddTestCase(
 		method, path, returnStatus,
 		nil, nil, "", responseBody)
@@ -153,9 +153,9 @@ func (s *Service) AddBillingUsageFilterChainsFailTestCase(
 // function
 func (s *Service) AddBillingUsageRecordsGetTestCase(
 	requestHeaders, responseHeaders http.Header,
-	response *billing_usage.TotalUsage,
+	response *billingusage.TotalUsage,
 ) error {
-	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageRecords)
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billingusage.BillingUsageRecords)
 	return s.AddTestCase(
 		http.MethodGet, path, http.StatusOK, requestHeaders,
 		responseHeaders, "", response,
@@ -169,7 +169,7 @@ func (s *Service) AddBillingUsageRecordFailTestCase(
 	requestHeaders, responseHeaders http.Header,
 	responseBody string,
 ) error {
-	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageRecords)
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billingusage.BillingUsageRecords)
 	return s.AddTestCase(
 		method, path, returnStatus,
 		nil, nil, "", responseBody)

--- a/mockns1/billing_usage.go
+++ b/mockns1/billing_usage.go
@@ -1,0 +1,176 @@
+package mockns1
+
+import (
+	"fmt"
+	"net/http"
+
+	billing_usage "gopkg.in/ns1/ns1-go.v2/rest/model/billing-usage"
+)
+
+// Should be identical to rest.billing_usage
+const billingUsagePath = "../billing-usage/v1/"
+
+// AddBillingUsageQueriesGetTestCase sets up a test case for the api.Client.BillingUsage.GetQueries(int32(from), int32(to))
+// function
+func (s *Service) AddBillingUsageQueriesGetTestCase(
+	from int32,
+	to int32,
+	requestHeaders, responseHeaders http.Header,
+	response *billing_usage.Queries,
+) error {
+
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageQueries, from, to)
+	return s.AddTestCase(
+		http.MethodGet, path, http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddBillingUsageQueriesFailTestCase sets up a test case for the api.Client.BillingUsage.GetQueries(int32(from), int32(to))
+// functions that fails.
+func (s *Service) AddBillingUsageQueriesFailTestCase(
+	method string, from int32, to int32, returnStatus int,
+	requestHeaders, responseHeaders http.Header,
+	responseBody string,
+) error {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageQueries, from, to)
+	return s.AddTestCase(
+		method, path, returnStatus,
+		nil, nil, "", responseBody)
+}
+
+// AddBillingUsageLimitsGetTestCase sets up a test case for the api.Client.BillingUsage.GetLimits(int32(from), int32(to))
+// function
+func (s *Service) AddBillingUsageLimitsGetTestCase(
+	from int32,
+	to int32,
+	requestHeaders, responseHeaders http.Header,
+	response *billing_usage.Limits,
+) error {
+
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageLimits, from, to)
+	return s.AddTestCase(
+		http.MethodGet, path, http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddBillingUsageLimitsFailTestCase sets up a test case for the api.Client.BillingUsage.GetLimits(int32(from), int32(to))
+// functions that fails.
+func (s *Service) AddBillingUsageLimitsFailTestCase(
+	method string, from int32, to int32, returnStatus int,
+	requestHeaders, responseHeaders http.Header,
+	responseBody string,
+) error {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageLimits, from, to)
+	return s.AddTestCase(
+		method, path, returnStatus,
+		nil, nil, "", responseBody)
+}
+
+// AddBillingUsageDecisionsGetTestCase sets up a test case for the api.Client.BillingUsage.GetDecisions(int32(from), int32(to))
+// function
+func (s *Service) AddBillingUsageDecisionsGetTestCase(
+	from int32,
+	to int32,
+	requestHeaders, responseHeaders http.Header,
+	response *billing_usage.TotalUsage,
+) error {
+
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageDecisions, from, to)
+	return s.AddTestCase(
+		http.MethodGet, path, http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddBillingUsageDecisionsFailTestCase sets up a test case for the api.Client.BillingUsage.GetDecisions(int32(from), int32(to))
+// functions that fails.
+func (s *Service) AddBillingUsageDecisionsFailTestCase(
+	method string, from int32, to int32, returnStatus int,
+	requestHeaders, responseHeaders http.Header,
+	responseBody string,
+) error {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsagePath, billing_usage.BillingUsageDecisions, from, to)
+	return s.AddTestCase(
+		method, path, returnStatus,
+		nil, nil, "", responseBody)
+}
+
+// AddBillingUsageMonitorsGetTestCase sets up a test case for the api.Client.BillingUsage.GetMonitors()
+// function
+func (s *Service) AddBillingUsageMonitorsGetTestCase(
+	requestHeaders, responseHeaders http.Header,
+	response *billing_usage.TotalUsage,
+) error {
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageMonitors)
+	return s.AddTestCase(
+		http.MethodGet, path, http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddBillingUsageMonitorsFailTestCase sets up a test case for the api.Client.BillingUsage.GetMonitors()
+// functions that fails.
+func (s *Service) AddBillingUsageMonitorsFailTestCase(
+	method string, returnStatus int,
+	requestHeaders, responseHeaders http.Header,
+	responseBody string,
+) error {
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageMonitors)
+	return s.AddTestCase(
+		method, path, returnStatus,
+		nil, nil, "", responseBody)
+}
+
+// AddBillingUsageFilterChainsGetTestCase sets up a test case for the api.Client.BillingUsage.FilterChains()
+// function
+func (s *Service) AddBillingUsageFilterChainsGetTestCase(
+	requestHeaders, responseHeaders http.Header,
+	response *billing_usage.TotalUsage,
+) error {
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageFilterChains)
+	return s.AddTestCase(
+		http.MethodGet, path, http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddBillingUsageFilterChainsFailTestCase sets up a test case for the api.Client.BillingUsage.FilterChains()
+// functions that fails.
+func (s *Service) AddBillingUsageFilterChainsFailTestCase(
+	method string, returnStatus int,
+	requestHeaders, responseHeaders http.Header,
+	responseBody string,
+) error {
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageFilterChains)
+	return s.AddTestCase(
+		method, path, returnStatus,
+		nil, nil, "", responseBody)
+}
+
+// AddBillingUsageRecordsGetTestCase sets up a test case for the api.Client.BillingUsage.GetRecords()
+// function
+func (s *Service) AddBillingUsageRecordsGetTestCase(
+	requestHeaders, responseHeaders http.Header,
+	response *billing_usage.TotalUsage,
+) error {
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageRecords)
+	return s.AddTestCase(
+		http.MethodGet, path, http.StatusOK, requestHeaders,
+		responseHeaders, "", response,
+	)
+}
+
+// AddBillingUsageRecordFailTestCase sets up a test case for the api.Client.BillingUsage.GetRecords()
+// functions that fails.
+func (s *Service) AddBillingUsageRecordFailTestCase(
+	method string, returnStatus int,
+	requestHeaders, responseHeaders http.Header,
+	responseBody string,
+) error {
+	path := fmt.Sprintf("%s/%s", billingUsagePath, billing_usage.BillingUsageRecords)
+	return s.AddTestCase(
+		method, path, returnStatus,
+		nil, nil, "", responseBody)
+}

--- a/rest/_examples/billing_usage.go
+++ b/rest/_examples/billing_usage.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	api "gopkg.in/ns1/ns1-go.v2/rest"
+)
+
+var client *api.Client
+
+// Helper that initializes rest api client from environment variable.
+func init() {
+	k := os.Getenv("NS1_APIKEY")
+	if k == "" {
+		fmt.Println("NS1_APIKEY environment variable is not set, giving up")
+	}
+
+	httpClient := &http.Client{Timeout: time.Second * 30}
+	// Adds logging to each http request.
+	doer := api.Decorate(httpClient, api.Logging(log.New(os.Stdout, "", log.LstdFlags)))
+	client = api.NewClient(doer, api.SetAPIKey(k))
+}
+
+func prettyPrint(header string, v interface{}) {
+	fmt.Println(header)
+	jsonBytes, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		return
+	}
+	fmt.Println(string(jsonBytes))
+}
+
+func main() {
+
+	queries, _, err := client.BillingUsage.GetQueries(1738368000, 1740787199)
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint("quiries", queries)
+
+	decisions, _, err := client.BillingUsage.GetDecisions(1738368000, 1740787199)
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint("decisions", decisions)
+
+	limits, _, err := client.BillingUsage.GetLimits(1738368000, 1740787199)
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint("limits", limits)
+
+	monitors, _, err := client.BillingUsage.GetMonitors()
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint("monitors", monitors)
+
+	filterChains, _, err := client.BillingUsage.GetFilterChains()
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint("filterChains", filterChains)
+
+	records, _, err := client.BillingUsage.GetRecords()
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint("records", records)
+
+}

--- a/rest/billing_usage.go
+++ b/rest/billing_usage.go
@@ -1,0 +1,178 @@
+package rest
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	billing_usage "gopkg.in/ns1/ns1-go.v2/rest/model/billing-usage"
+)
+
+// BillingUsageService handles 'billimg-usage/v1' endpoint.
+type BillingUsageService service
+
+// The base for the billing-usage api relative to /v1
+// client.NewRequest will call ResolveReference and remove /v1/../
+const billingUsageRelativeBase = "../billing-usage/v1"
+
+// GetQueries takes the timeframe input "from" and "to", returns all its queries.
+// NS1 API docs: https://ns1.com/api/#billing-usage-queries-get
+func (bu *BillingUsageService) GetQueries(from int32, to int32) (*billing_usage.Queries, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billing_usage.BillingUsageQueries, from, to)
+	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var queries billing_usage.Queries
+
+	resp, err := bu.client.Do(req, &queries)
+	if err != nil {
+		var clientErr *Error
+		switch {
+		case errors.As(err, &clientErr):
+			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
+				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			}
+		}
+		return nil, resp, err
+	}
+
+	return &queries, resp, nil
+}
+
+// GetDecisions takes the timeframe input "from" and "to", returns all its decisions.
+// NS1 API docs: https://ns1.com/api/#billing-usage-decisions-get
+func (bu *BillingUsageService) GetDecisions(from int32, to int32) (*billing_usage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billing_usage.BillingUsageDecisions, from, to)
+
+	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var decisions billing_usage.TotalUsage
+
+	resp, err := bu.client.Do(req, &decisions)
+	if err != nil {
+		var clientErr *Error
+		switch {
+		case errors.As(err, &clientErr):
+			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
+				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			}
+		}
+		return nil, resp, err
+	}
+
+	return &decisions, resp, nil
+}
+
+// GetLimits takes the timeframe input "from" and "to", returns all its limits.
+// NS1 API docs: https://ns1.com/api/#billing-usage-limits-get
+func (bu *BillingUsageService) GetLimits(from int32, to int32) (*billing_usage.Limits, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billing_usage.BillingUsageLimits, from, to)
+
+	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var limits billing_usage.Limits
+
+	resp, err := bu.client.Do(req, &limits)
+	if err != nil {
+		var clientErr *Error
+		switch {
+		case errors.As(err, &clientErr):
+			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
+				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			}
+		}
+		return nil, resp, err
+	}
+
+	return &limits, resp, nil
+}
+
+// GetMonitors returns total no. of monitors.
+// NS1 API docs: https://ns1.com/api/#billing-usage-monitors-get
+func (bu *BillingUsageService) GetMonitors() (*billing_usage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billing_usage.BillingUsageMonitors)
+
+	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var monitors billing_usage.TotalUsage
+
+	resp, err := bu.client.Do(req, &monitors)
+	if err != nil {
+		var clientErr *Error
+		switch {
+		case errors.As(err, &clientErr):
+			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
+				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			}
+		}
+		return nil, resp, err
+	}
+
+	return &monitors, resp, nil
+}
+
+// GetFilterChains returns total no. of filter-chains.
+// NS1 API docs: https://ns1.com/api/#billing-usage-filter-chains-get
+func (bu *BillingUsageService) GetFilterChains() (*billing_usage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billing_usage.BillingUsageFilterChains)
+
+	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var filterChains billing_usage.TotalUsage
+
+	resp, err := bu.client.Do(req, &filterChains)
+	if err != nil {
+		var clientErr *Error
+		switch {
+		case errors.As(err, &clientErr):
+			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
+				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			}
+		}
+		return nil, resp, err
+	}
+
+	return &filterChains, resp, nil
+}
+
+// GetRecords returns total no. of records.
+// NS1 API docs: https://ns1.com/api/#billing-usage-records-get
+func (bu *BillingUsageService) GetRecords() (*billing_usage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billing_usage.BillingUsageRecords)
+
+	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var records billing_usage.TotalUsage
+
+	resp, err := bu.client.Do(req, &records)
+	if err != nil {
+		var clientErr *Error
+		switch {
+		case errors.As(err, &clientErr):
+			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
+				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			}
+		}
+		return nil, resp, err
+	}
+
+	return &records, resp, nil
+}

--- a/rest/billing_usage.go
+++ b/rest/billing_usage.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	billing_usage "gopkg.in/ns1/ns1-go.v2/rest/model/billing-usage"
+	billingusage "gopkg.in/ns1/ns1-go.v2/rest/model/billingusage"
 )
 
 // BillingUsageService handles 'billimg-usage/v1' endpoint.
@@ -18,22 +18,22 @@ const billingUsageRelativeBase = "../billing-usage/v1"
 
 // GetQueries takes the timeframe input "from" and "to", returns all its queries.
 // NS1 API docs: https://ns1.com/api/#billing-usage-queries-get
-func (bu *BillingUsageService) GetQueries(from int32, to int32) (*billing_usage.Queries, *http.Response, error) {
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billing_usage.BillingUsageQueries, from, to)
+func (bu *BillingUsageService) GetQueries(from int32, to int32) (*billingusage.Queries, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billingusage.BillingUsageQueries, from, to)
 	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var queries billing_usage.Queries
+	var queries billingusage.Queries
 
 	resp, err := bu.client.Do(req, &queries)
 	if err != nil {
 		var clientErr *Error
 		switch {
 		case errors.As(err, &clientErr):
-			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
-				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			if strings.HasSuffix(clientErr.Message, billingusage.NotFound) {
+				return nil, resp, billingusage.ErrBillingUsageNotFound
 			}
 		}
 		return nil, resp, err
@@ -44,23 +44,23 @@ func (bu *BillingUsageService) GetQueries(from int32, to int32) (*billing_usage.
 
 // GetDecisions takes the timeframe input "from" and "to", returns all its decisions.
 // NS1 API docs: https://ns1.com/api/#billing-usage-decisions-get
-func (bu *BillingUsageService) GetDecisions(from int32, to int32) (*billing_usage.TotalUsage, *http.Response, error) {
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billing_usage.BillingUsageDecisions, from, to)
+func (bu *BillingUsageService) GetDecisions(from int32, to int32) (*billingusage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billingusage.BillingUsageDecisions, from, to)
 
 	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var decisions billing_usage.TotalUsage
+	var decisions billingusage.TotalUsage
 
 	resp, err := bu.client.Do(req, &decisions)
 	if err != nil {
 		var clientErr *Error
 		switch {
 		case errors.As(err, &clientErr):
-			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
-				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			if strings.HasSuffix(clientErr.Message, billingusage.NotFound) {
+				return nil, resp, billingusage.ErrBillingUsageNotFound
 			}
 		}
 		return nil, resp, err
@@ -71,23 +71,23 @@ func (bu *BillingUsageService) GetDecisions(from int32, to int32) (*billing_usag
 
 // GetLimits takes the timeframe input "from" and "to", returns all its limits.
 // NS1 API docs: https://ns1.com/api/#billing-usage-limits-get
-func (bu *BillingUsageService) GetLimits(from int32, to int32) (*billing_usage.Limits, *http.Response, error) {
-	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billing_usage.BillingUsageLimits, from, to)
+func (bu *BillingUsageService) GetLimits(from int32, to int32) (*billingusage.Limits, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s?from=%d&to=%d", billingUsageRelativeBase, billingusage.BillingUsageLimits, from, to)
 
 	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var limits billing_usage.Limits
+	var limits billingusage.Limits
 
 	resp, err := bu.client.Do(req, &limits)
 	if err != nil {
 		var clientErr *Error
 		switch {
 		case errors.As(err, &clientErr):
-			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
-				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			if strings.HasSuffix(clientErr.Message, billingusage.NotFound) {
+				return nil, resp, billingusage.ErrBillingUsageNotFound
 			}
 		}
 		return nil, resp, err
@@ -98,23 +98,23 @@ func (bu *BillingUsageService) GetLimits(from int32, to int32) (*billing_usage.L
 
 // GetMonitors returns total no. of monitors.
 // NS1 API docs: https://ns1.com/api/#billing-usage-monitors-get
-func (bu *BillingUsageService) GetMonitors() (*billing_usage.TotalUsage, *http.Response, error) {
-	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billing_usage.BillingUsageMonitors)
+func (bu *BillingUsageService) GetMonitors() (*billingusage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billingusage.BillingUsageMonitors)
 
 	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var monitors billing_usage.TotalUsage
+	var monitors billingusage.TotalUsage
 
 	resp, err := bu.client.Do(req, &monitors)
 	if err != nil {
 		var clientErr *Error
 		switch {
 		case errors.As(err, &clientErr):
-			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
-				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			if strings.HasSuffix(clientErr.Message, billingusage.NotFound) {
+				return nil, resp, billingusage.ErrBillingUsageNotFound
 			}
 		}
 		return nil, resp, err
@@ -125,23 +125,23 @@ func (bu *BillingUsageService) GetMonitors() (*billing_usage.TotalUsage, *http.R
 
 // GetFilterChains returns total no. of filter-chains.
 // NS1 API docs: https://ns1.com/api/#billing-usage-filter-chains-get
-func (bu *BillingUsageService) GetFilterChains() (*billing_usage.TotalUsage, *http.Response, error) {
-	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billing_usage.BillingUsageFilterChains)
+func (bu *BillingUsageService) GetFilterChains() (*billingusage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billingusage.BillingUsageFilterChains)
 
 	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var filterChains billing_usage.TotalUsage
+	var filterChains billingusage.TotalUsage
 
 	resp, err := bu.client.Do(req, &filterChains)
 	if err != nil {
 		var clientErr *Error
 		switch {
 		case errors.As(err, &clientErr):
-			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
-				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			if strings.HasSuffix(clientErr.Message, billingusage.NotFound) {
+				return nil, resp, billingusage.ErrBillingUsageNotFound
 			}
 		}
 		return nil, resp, err
@@ -152,23 +152,23 @@ func (bu *BillingUsageService) GetFilterChains() (*billing_usage.TotalUsage, *ht
 
 // GetRecords returns total no. of records.
 // NS1 API docs: https://ns1.com/api/#billing-usage-records-get
-func (bu *BillingUsageService) GetRecords() (*billing_usage.TotalUsage, *http.Response, error) {
-	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billing_usage.BillingUsageRecords)
+func (bu *BillingUsageService) GetRecords() (*billingusage.TotalUsage, *http.Response, error) {
+	path := fmt.Sprintf("%s/%s", billingUsageRelativeBase, billingusage.BillingUsageRecords)
 
 	req, err := bu.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var records billing_usage.TotalUsage
+	var records billingusage.TotalUsage
 
 	resp, err := bu.client.Do(req, &records)
 	if err != nil {
 		var clientErr *Error
 		switch {
 		case errors.As(err, &clientErr):
-			if strings.HasSuffix(clientErr.Message, billing_usage.NotFound) {
-				return nil, resp, billing_usage.ErrBillingUsageNotFound
+			if strings.HasSuffix(clientErr.Message, billingusage.NotFound) {
+				return nil, resp, billingusage.ErrBillingUsageNotFound
 			}
 		}
 		return nil, resp, err

--- a/rest/billing_usage_test.go
+++ b/rest/billing_usage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ns1/ns1-go.v2/mockns1"
 	api "gopkg.in/ns1/ns1-go.v2/rest"
-	billing_usage "gopkg.in/ns1/ns1-go.v2/rest/model/billing-usage"
+	billingusage "gopkg.in/ns1/ns1-go.v2/rest/model/billingusage"
 )
 
 func TestBillingUsageService(t *testing.T) {
@@ -25,13 +25,11 @@ func TestBillingUsageService(t *testing.T) {
 	t.Run("Get Billing Usage Queries", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			defer mock.ClearTestCases()
-
-			client.FollowPagination = true
-			queries := &billing_usage.Queries{
+			queries := &billingusage.Queries{
 				CleanQueries: 0,
 				DdosQueries:  0,
 				NxdResponses: 0,
-				ByNetwork:    []billing_usage.ByNetwork{},
+				ByNetwork:    []billingusage.QueriesByNetwork{},
 			}
 			require.Nil(t, mock.AddBillingUsageQueriesGetTestCase(int32(from), int32(to), nil, nil, queries))
 
@@ -71,9 +69,7 @@ func TestBillingUsageService(t *testing.T) {
 	t.Run("Get Billing Usage Limits", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			defer mock.ClearTestCases()
-
-			client.FollowPagination = true
-			limits := &billing_usage.Limits{
+			limits := &billingusage.Limits{
 				QueriesLimit:          0,
 				ChinaQueriesLimit:     0,
 				RecordsLimit:          0,
@@ -122,9 +118,7 @@ func TestBillingUsageService(t *testing.T) {
 	t.Run("Get Billing Usage Decisions", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			defer mock.ClearTestCases()
-
-			client.FollowPagination = true
-			decisions := &billing_usage.TotalUsage{
+			decisions := &billingusage.TotalUsage{
 				TotalUsage: 0,
 			}
 			require.Nil(t, mock.AddBillingUsageDecisionsGetTestCase(int32(from), int32(to), nil, nil, decisions))
@@ -165,9 +159,7 @@ func TestBillingUsageService(t *testing.T) {
 	t.Run("Get Billing Usage Monitors", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			defer mock.ClearTestCases()
-
-			client.FollowPagination = true
-			records := &billing_usage.TotalUsage{
+			records := &billingusage.TotalUsage{
 				TotalUsage: 0,
 			}
 			require.Nil(t, mock.AddBillingUsageMonitorsGetTestCase(nil, nil, records))
@@ -208,9 +200,7 @@ func TestBillingUsageService(t *testing.T) {
 	t.Run("Get Billing Usage FilterChains", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			defer mock.ClearTestCases()
-
-			client.FollowPagination = true
-			filterChains := &billing_usage.TotalUsage{
+			filterChains := &billingusage.TotalUsage{
 				TotalUsage: 0,
 			}
 			require.Nil(t, mock.AddBillingUsageFilterChainsGetTestCase(nil, nil, filterChains))
@@ -251,9 +241,7 @@ func TestBillingUsageService(t *testing.T) {
 	t.Run("Get Billing Usage Records", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			defer mock.ClearTestCases()
-
-			client.FollowPagination = true
-			records := &billing_usage.TotalUsage{
+			records := &billingusage.TotalUsage{
 				TotalUsage: 0,
 			}
 			require.Nil(t, mock.AddBillingUsageRecordsGetTestCase(nil, nil, records))

--- a/rest/billing_usage_test.go
+++ b/rest/billing_usage_test.go
@@ -1,0 +1,293 @@
+package rest_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ns1/ns1-go.v2/mockns1"
+	api "gopkg.in/ns1/ns1-go.v2/rest"
+	billing_usage "gopkg.in/ns1/ns1-go.v2/rest/model/billing-usage"
+)
+
+func TestBillingUsageService(t *testing.T) {
+
+	mock, doer, err := mockns1.New(t)
+	require.Nil(t, err)
+	defer mock.Shutdown()
+
+	from := 1738368000
+	to := 1740787199
+
+	client := api.NewClient(doer, api.SetEndpoint("https://"+mock.Address+"/v1/"))
+
+	// Tests for api.Client.BillingUsage.GetQueries
+	t.Run("Get Billing Usage Queries", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			defer mock.ClearTestCases()
+
+			client.FollowPagination = true
+			queries := &billing_usage.Queries{
+				CleanQueries: 0,
+				DdosQueries:  0,
+				NxdResponses: 0,
+				ByNetwork:    []billing_usage.ByNetwork{},
+			}
+			require.Nil(t, mock.AddBillingUsageQueriesGetTestCase(int32(from), int32(to), nil, nil, queries))
+
+			respDt, _, err := client.BillingUsage.GetQueries(int32(from), int32(to))
+			require.Nil(t, err)
+			require.NotNil(t, respDt)
+			require.Equal(t, queries.CleanQueries, respDt.CleanQueries)
+		})
+
+		t.Run("Error Get Billing Usage Queries", func(t *testing.T) {
+			t.Run("HTTP", func(t *testing.T) {
+				defer mock.ClearTestCases()
+
+				require.Nil(t, mock.AddBillingUsageQueriesFailTestCase(
+					http.MethodGet, int32(from), int32(to), http.StatusNotFound,
+					nil, nil, `{"message": "not found"}`,
+				))
+
+				dt, resp, err := client.BillingUsage.GetQueries(int32(from), int32(to))
+				require.Nil(t, dt)
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), "not found")
+				require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			})
+
+			t.Run("Other", func(t *testing.T) {
+				c := api.NewClient(errorClient{}, api.SetEndpoint(""))
+				dt, resp, err := c.BillingUsage.GetQueries(int32(from), int32(to))
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Nil(t, dt)
+			})
+		})
+	})
+
+	// Tests for api.Client.BillingUsage.GetLimits
+	t.Run("Get Billing Usage Limits", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			defer mock.ClearTestCases()
+
+			client.FollowPagination = true
+			limits := &billing_usage.Limits{
+				QueriesLimit:          0,
+				ChinaQueriesLimit:     0,
+				RecordsLimit:          0,
+				FilterChainsLimit:     0,
+				MonitorsLimit:         0,
+				DecisionsLimit:        0,
+				NxdProtectionEnabled:  false,
+				DdosProtectionEnabled: false,
+				IncludeDedicatedDnsNetworkInManagedDnsUsage: false,
+			}
+			require.Nil(t, mock.AddBillingUsageLimitsGetTestCase(int32(from), int32(to), nil, nil, limits))
+
+			buLimits, _, err := client.BillingUsage.GetLimits(int32(from), int32(to))
+			require.Nil(t, err)
+			require.NotNil(t, buLimits)
+			require.Equal(t, limits, buLimits)
+		})
+
+		t.Run("Error Get Billing Usage Limits", func(t *testing.T) {
+			t.Run("HTTP", func(t *testing.T) {
+				defer mock.ClearTestCases()
+
+				require.Nil(t, mock.AddBillingUsageLimitsFailTestCase(
+					http.MethodGet, int32(from), int32(to), http.StatusNotFound,
+					nil, nil, `{"message": "not found"}`,
+				))
+
+				dt, resp, err := client.BillingUsage.GetLimits(int32(from), int32(to))
+				require.Nil(t, dt)
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), "not found")
+				require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			})
+
+			t.Run("Other", func(t *testing.T) {
+				c := api.NewClient(errorClient{}, api.SetEndpoint(""))
+				dt, resp, err := c.BillingUsage.GetLimits(int32(from), int32(to))
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Nil(t, dt)
+			})
+		})
+	})
+
+	// Tests for api.Client.BillingUsage.GetDecisions
+	t.Run("Get Billing Usage Decisions", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			defer mock.ClearTestCases()
+
+			client.FollowPagination = true
+			decisions := &billing_usage.TotalUsage{
+				TotalUsage: 0,
+			}
+			require.Nil(t, mock.AddBillingUsageDecisionsGetTestCase(int32(from), int32(to), nil, nil, decisions))
+
+			buDecisions, _, err := client.BillingUsage.GetDecisions(int32(from), int32(to))
+			require.Nil(t, err)
+			require.NotNil(t, buDecisions)
+			require.Equal(t, decisions.TotalUsage, buDecisions.TotalUsage)
+		})
+
+		t.Run("Error Get Billing Usage Decisions", func(t *testing.T) {
+			t.Run("HTTP", func(t *testing.T) {
+				defer mock.ClearTestCases()
+
+				require.Nil(t, mock.AddBillingUsageDecisionsFailTestCase(
+					http.MethodGet, int32(from), int32(to), http.StatusNotFound,
+					nil, nil, `{"message": "not found"}`,
+				))
+
+				dt, resp, err := client.BillingUsage.GetDecisions(int32(from), int32(to))
+				require.Nil(t, dt)
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), "not found")
+				require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			})
+
+			t.Run("Other", func(t *testing.T) {
+				c := api.NewClient(errorClient{}, api.SetEndpoint(""))
+				dt, resp, err := c.BillingUsage.GetDecisions(int32(from), int32(to))
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Nil(t, dt)
+			})
+		})
+	})
+
+	// Tests for api.Client.BillingUsage.GetMonitors
+	t.Run("Get Billing Usage Monitors", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			defer mock.ClearTestCases()
+
+			client.FollowPagination = true
+			records := &billing_usage.TotalUsage{
+				TotalUsage: 0,
+			}
+			require.Nil(t, mock.AddBillingUsageMonitorsGetTestCase(nil, nil, records))
+
+			buMonitors, _, err := client.BillingUsage.GetMonitors()
+			require.Nil(t, err)
+			require.NotNil(t, buMonitors)
+			require.Equal(t, records.TotalUsage, buMonitors.TotalUsage)
+		})
+
+		t.Run("Error Get Billing Usage Monitors", func(t *testing.T) {
+			t.Run("HTTP", func(t *testing.T) {
+				defer mock.ClearTestCases()
+
+				require.Nil(t, mock.AddBillingUsageMonitorsFailTestCase(
+					http.MethodGet, http.StatusNotFound,
+					nil, nil, `{"message": "not found"}`,
+				))
+
+				buMonitors, resp, err := client.BillingUsage.GetMonitors()
+				require.Nil(t, buMonitors)
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), "not found")
+				require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			})
+
+			t.Run("Other", func(t *testing.T) {
+				c := api.NewClient(errorClient{}, api.SetEndpoint(""))
+				dt, resp, err := c.BillingUsage.GetMonitors()
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Nil(t, dt)
+			})
+		})
+	})
+
+	// Tests for api.Client.BillingUsage.GetFilterChains
+	t.Run("Get Billing Usage FilterChains", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			defer mock.ClearTestCases()
+
+			client.FollowPagination = true
+			filterChains := &billing_usage.TotalUsage{
+				TotalUsage: 0,
+			}
+			require.Nil(t, mock.AddBillingUsageFilterChainsGetTestCase(nil, nil, filterChains))
+
+			buFilterChains, _, err := client.BillingUsage.GetFilterChains()
+			require.Nil(t, err)
+			require.NotNil(t, buFilterChains)
+			require.Equal(t, filterChains.TotalUsage, buFilterChains.TotalUsage)
+		})
+
+		t.Run("Error Get Billing Usage FilterChains", func(t *testing.T) {
+			t.Run("HTTP", func(t *testing.T) {
+				defer mock.ClearTestCases()
+
+				require.Nil(t, mock.AddBillingUsageFilterChainsFailTestCase(
+					http.MethodGet, http.StatusNotFound,
+					nil, nil, `{"message": "not found"}`,
+				))
+
+				buFilterChains, resp, err := client.BillingUsage.GetFilterChains()
+				require.Nil(t, buFilterChains)
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), "not found")
+				require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			})
+
+			t.Run("Other", func(t *testing.T) {
+				c := api.NewClient(errorClient{}, api.SetEndpoint(""))
+				dt, resp, err := c.BillingUsage.GetFilterChains()
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Nil(t, dt)
+			})
+		})
+	})
+
+	// Tests for api.Client.BillingUsage.GetRecords
+	t.Run("Get Billing Usage Records", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			defer mock.ClearTestCases()
+
+			client.FollowPagination = true
+			records := &billing_usage.TotalUsage{
+				TotalUsage: 0,
+			}
+			require.Nil(t, mock.AddBillingUsageRecordsGetTestCase(nil, nil, records))
+
+			buRecords, _, err := client.BillingUsage.GetRecords()
+			require.Nil(t, err)
+			require.NotNil(t, buRecords)
+			require.Equal(t, records.TotalUsage, buRecords.TotalUsage)
+		})
+
+		t.Run("Error Get Billing Usage Records", func(t *testing.T) {
+			t.Run("HTTP", func(t *testing.T) {
+				defer mock.ClearTestCases()
+
+				require.Nil(t, mock.AddBillingUsageRecordFailTestCase(
+					http.MethodGet, http.StatusNotFound,
+					nil, nil, `{"message": "not found"}`,
+				))
+
+				buRecords, resp, err := client.BillingUsage.GetRecords()
+				require.Nil(t, buRecords)
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), "not found")
+				require.Equal(t, http.StatusNotFound, resp.StatusCode)
+			})
+
+			t.Run("Other", func(t *testing.T) {
+				c := api.NewClient(errorClient{}, api.SetEndpoint(""))
+				dt, resp, err := c.BillingUsage.GetRecords()
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Nil(t, dt)
+			})
+		})
+	})
+
+}

--- a/rest/client.go
+++ b/rest/client.go
@@ -87,6 +87,7 @@ type Client struct {
 	Redirects            *RedirectService
 	RedirectCertificates *RedirectCertificateService
 	Alerts               *AlertsService
+	BillingUsage         *BillingUsageService
 }
 
 // NewClient constructs and returns a reference to an instantiated Client.
@@ -134,6 +135,7 @@ func NewClient(httpClient Doer, options ...func(*Client)) *Client {
 	c.Redirects = (*RedirectService)(&c.common)
 	c.RedirectCertificates = (*RedirectCertificateService)(&c.common)
 	c.Alerts = (*AlertsService)(&c.common)
+	c.BillingUsage = (*BillingUsageService)(&c.common)
 
 	for _, option := range options {
 		option(c)

--- a/rest/model/billing-usage/billing_usage.go
+++ b/rest/model/billing-usage/billing_usage.go
@@ -1,0 +1,65 @@
+package billing_usage
+
+import "errors"
+
+type BillingUsage string
+
+// constants values for billing-usage module implementations
+const (
+	BillingUsageQueries      = BillingUsage("queries")
+	BillingUsageLimits       = BillingUsage("limits")
+	BillingUsageDecisions    = BillingUsage("decisions")
+	BillingUsageMonitors     = BillingUsage("monitors")
+	BillingUsageFilterChains = BillingUsage("filter-chains")
+	BillingUsageRecords      = BillingUsage("records")
+)
+
+var (
+	// ErrBillingUsageNotFound bundles GET not found errors.
+	ErrBillingUsageNotFound        = errors.New("billing_usage not found")
+	NotFound                string = " not found"
+)
+
+// wraps an NS1 /billing-usage-queries resource
+type Queries struct {
+	CleanQueries int32       `json:"clean_queries"`
+	DdosQueries  int32       `json:"ddos_queries"`
+	NxdResponses int32       `json:"nxd_responses"`
+	ByNetwork    []ByNetwork `json:"by_network"`
+}
+
+// wraps an NS1 /billing-usage-limits resource
+type Limits struct {
+	QueriesLimit                                int32 `json:"queries_limit"`
+	ChinaQueriesLimit                           int32 `json:"china_queries_limit"`
+	RecordsLimit                                int32 `json:"records_limit"`
+	FilterChainsLimit                           int32 `json:"tefilter_chains_limitams"`
+	MonitorsLimit                               int32 `json:"monitors_limit"`
+	DecisionsLimit                              int32 `json:"decisions_limit"`
+	NxdProtectionEnabled                        bool  `json:"nxd_protection_enabled"`
+	DdosProtectionEnabled                       bool  `json:"ddos_protection_enabled"`
+	IncludeDedicatedDnsNetworkInManagedDnsUsage bool  `json:"include_dedicated_dns_network_in_managed_dns_usage"`
+}
+
+// wraps an NS1 /billing-usage-queries.ByNetwork resource
+type ByNetwork struct {
+	Network         int32   `json:"network"`
+	CleanQueries    int32   `json:"clean_queries"`
+	DdosQueries     int32   `json:"ddos_queries"`
+	NxdResponses    int32   `json:"nxd_responses"`
+	BillableQueries int32   `json:"billable_queries"`
+	Daily           []Daily `json:"daily"`
+}
+
+// wraps an NS1 /billing-usage-queries.ByNetwork.Daily resource
+type Daily struct {
+	Timestamp    int32 `json:"timestamp"`
+	CleanQueries int32 `json:"clean_queries"`
+	DdosQueries  int32 `json:"ddos_queries"`
+	NxdResponses int32 `json:"nxd_responses"`
+}
+
+// wraps an NS1 /billing-usage-monitors, billing-usage-decisions, billing-usage-records resource
+type TotalUsage struct {
+	TotalUsage int32 `json:"total_usage"`
+}

--- a/rest/model/billingusage/billing_usage.go
+++ b/rest/model/billingusage/billing_usage.go
@@ -16,19 +16,19 @@ const (
 
 var (
 	// ErrBillingUsageNotFound bundles GET not found errors.
-	ErrBillingUsageNotFound        = errors.New("billing_usage not found")
-	NotFound                string = " not found"
+	ErrBillingUsageNotFound = errors.New("billing_usage not found")
+	NotFound                = " not found"
 )
 
-// wraps an NS1 /billing-usage-queries resource
+// Queries wraps an NS1 /billing-usage-queries resource
 type Queries struct {
-	CleanQueries int32       `json:"clean_queries"`
-	DdosQueries  int32       `json:"ddos_queries"`
-	NxdResponses int32       `json:"nxd_responses"`
-	ByNetwork    []ByNetwork `json:"by_network"`
+	CleanQueries int32              `json:"clean_queries"`
+	DdosQueries  int32              `json:"ddos_queries"`
+	NxdResponses int32              `json:"nxd_responses"`
+	ByNetwork    []QueriesByNetwork `json:"by_network"`
 }
 
-// wraps an NS1 /billing-usage-limits resource
+// Limits wraps an NS1 /billing-usage-limits resource
 type Limits struct {
 	QueriesLimit                                int32 `json:"queries_limit"`
 	ChinaQueriesLimit                           int32 `json:"china_queries_limit"`
@@ -41,18 +41,18 @@ type Limits struct {
 	IncludeDedicatedDnsNetworkInManagedDnsUsage bool  `json:"include_dedicated_dns_network_in_managed_dns_usage"`
 }
 
-// wraps an NS1 /billing-usage-queries.ByNetwork resource
-type ByNetwork struct {
-	Network         int32   `json:"network"`
-	CleanQueries    int32   `json:"clean_queries"`
-	DdosQueries     int32   `json:"ddos_queries"`
-	NxdResponses    int32   `json:"nxd_responses"`
-	BillableQueries int32   `json:"billable_queries"`
-	Daily           []Daily `json:"daily"`
+// QueriesByNetwork wraps an NS1 /billing-usage-queries.ByNetwork resource
+type QueriesByNetwork struct {
+	Network         int32                   `json:"network"`
+	CleanQueries    int32                   `json:"clean_queries"`
+	DdosQueries     int32                   `json:"ddos_queries"`
+	NxdResponses    int32                   `json:"nxd_responses"`
+	BillableQueries int32                   `json:"billable_queries"`
+	Daily           []QueriesByNetworkDaily `json:"daily"`
 }
 
-// wraps an NS1 /billing-usage-queries.ByNetwork.Daily resource
-type Daily struct {
+// QueriesByNetworkDaily an NS1 /billing-usage-queries.ByNetwork.Daily resource
+type QueriesByNetworkDaily struct {
 	Timestamp    int32 `json:"timestamp"`
 	CleanQueries int32 `json:"clean_queries"`
 	DdosQueries  int32 `json:"ddos_queries"`


### PR DESCRIPTION
Implementation of billing-usage GET requests for the below endpoints -

GET/billing-usage/v1/queries
GET/billing-usage/v1/decisions
GET/billing-usage/v1/filter-chains
GET/billing-usage/v1/monitors
GET/billing-usage/v1/records
GET/billing-usage/v1/limits