### PR TITLE
INBOX-3419 - Add support for primary_network on secondary zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
+## 2.14.2 (April 8th, 2025)
+FEATURES:
 
-### 2.14.1 (April 4th, 2025)
+* Adds support for `primary_network` for secondary zones
+
+## 2.14.1 (April 4th, 2025)
 
 BUG FIXES:
 
 * Fixing billing usage models to use `int64` instead of `int` for all usage values
 
-# 2.14.0 (March 31st, 2025)
+## 2.14.0 (March 31st, 2025)
 
 FEATURES:
 
@@ -18,7 +22,7 @@ FEATURES:
     GET/billing-usage/v1/limits
 
 
-## 2.13.0 (Dec 5th, 2024)
+## 2.13.0 (December 5th, 2024)
 
 FEATURES:
 
@@ -30,14 +34,14 @@ BUG FIXES:
 
 * Allowing to wipe the record regions
 
-## 2.12.1 (Sep 23rd, 2024)
+## 2.12.1 (September 23rd, 2024)
 
 BUG FIXES:
 
 * Adds "feeds" field to the Answer struct
 * Adds "destinations" field to the Feed struct
 
-## 2.12.0 (Jul 19th, 2024)
+## 2.12.0 (July 19th, 2024)
 
 FEATURES:
 

--- a/rest/client.go
+++ b/rest/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	clientVersion = "2.14.1"
+	clientVersion = "2.14.2"
 
 	defaultBase                   = "https://api.nsone.net"
 	defaultEndpoint               = defaultBase + "/v1/"

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -98,9 +98,10 @@ type ZoneSecondary struct {
 	Status  string  `json:"status,omitempty"`
 	Error   *string `json:"error"`
 
-	PrimaryIP   string `json:"primary_ip,omitempty"`
-	PrimaryPort int    `json:"primary_port,omitempty"`
-	Enabled     bool   `json:"enabled"`
+	PrimaryIP      string `json:"primary_ip,omitempty"`
+	PrimaryPort    int    `json:"primary_port,omitempty"`
+	PrimaryNetwork int    `json:"primary_network"`
+	Enabled        bool   `json:"enabled"`
 
 	OtherIPs      []string `json:"other_ips,omitempty"`
 	OtherPorts    []int    `json:"other_ports,omitempty"`

--- a/rest/model/dns/zone_test.go
+++ b/rest/model/dns/zone_test.go
@@ -110,6 +110,7 @@ func TestUnmarshalZones(t *testing.T) {
         "last_xfr":0,
         "primary_ip":"1.1.1.1",
         "primary_port":53,
+        "primary_network": 5,
       "other_ips":[
       "1.1.1.2",
       "1.1.1.3"
@@ -265,6 +266,7 @@ func TestUnmarshalZones(t *testing.T) {
 	assert.Equal(t, secondary.LastXfr, 0, "Wrong zone secondary last xfr")
 	assert.Equal(t, secondary.PrimaryIP, "1.1.1.1", "Wrong zone secondary primary ip")
 	assert.Equal(t, secondary.PrimaryPort, 53, "Wrong zone secondary primary port")
+	assert.Equal(t, 5, secondary.PrimaryNetwork, "Wrong zone secondary primary network")
 	assert.Equal(t, secondary.Enabled, true, "Wrong zone secondary enabled")
 	assert.ElementsMatch(t, secondary.OtherIPs, []string{"1.1.1.2", "1.1.1.3"}, "Wrong zone secondary list of other IPs")
 	assert.ElementsMatch(t, secondary.OtherPorts, []int{53, 53}, "Wrong zone secondary list of other ports")


### PR DESCRIPTION
1. Added primary_network field to secondary zones
2. Fixed heading levels and date formats