### PR TITLE
Fix/zone networks empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.15.1 (November 25th, 2025)
+
+FEATURES:
+
+* Fix zone create with empty networks field
+
 ## 2.15.0 (August 28th, 2025)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 2.15.1 (November 25th, 2025)
+## 2.15.2 (November 25th, 2025)
 
-FEATURES:
+BUG FIXES:
 
 * Fix zone create with empty networks field
+
+## 2.15.1 (October 20th, 2025)
+
+BUG FIXES:
+
+* Fix data source update incorrectly adding the id into the body
 
 ## 2.15.0 (August 28th, 2025)
 

--- a/rest/client.go
+++ b/rest/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	clientVersion = "2.15.1"
+	clientVersion = "2.15.2"
 
 	defaultBase                   = "https://api.nsone.net"
 	defaultEndpoint               = defaultBase + "/v1/"

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -35,9 +35,10 @@ type Zone struct {
 
 	// Networks contains the network ids the zone is available. Most zones
 	// will be in the NSONE Global Network(which is id 0).
-	NetworkIDs []int         `json:"-"`
-	Networks   *[]int        `json:"networks"`
-	Records    []*ZoneRecord `json:"records,omitempty"`
+	NetworkIDs []int `json:"-"`
+	// Networks is an Auxiliary field to help with JSON marshalling/unmarshalling of NetworkIDs for internal use only
+	Networks *[]int        `json:"networks"`
+	Records  []*ZoneRecord `json:"records,omitempty"`
 
 	// Primary contains info to enable slaving of the zone by third party dns servers.
 	Primary *ZonePrimary `json:"primary,omitempty"`

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -37,7 +37,7 @@ type Zone struct {
 	// will be in the NSONE Global Network(which is id 0).
 	NetworkIDs []int `json:"-"`
 	// Networks is an Auxiliary field to help with JSON marshalling/unmarshalling of NetworkIDs for internal use only
-	Networks *[]int        `json:"networks"`
+	Networks *[]int        `json:"networks,omitempty"`
 	Records  []*ZoneRecord `json:"records,omitempty"`
 
 	// Primary contains info to enable slaving of the zone by third party dns servers.
@@ -63,10 +63,8 @@ func (z Zone) MarshalJSON() ([]byte, error) {
 
 	if z.NetworkIDs != nil {
 		aux.Networks = &z.NetworkIDs
-	}
-
-	if aux.Networks == nil {
-		aux.Networks = &[]int{}
+	} else {
+		aux.Networks = nil
 	}
 
 	return json.Marshal(aux)
@@ -87,7 +85,7 @@ func (z *Zone) UnmarshalJSON(data []byte) error {
 	if aux.Networks != nil {
 		z.NetworkIDs = *aux.Networks
 	} else {
-		z.NetworkIDs = []int{}
+		z.NetworkIDs = nil
 	}
 
 	return nil

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -36,7 +36,7 @@ type Zone struct {
 	// Networks contains the network ids the zone is available. Most zones
 	// will be in the NSONE Global Network(which is id 0).
 	NetworkIDs []int         `json:"-"`
-	Networks   *[]int        `json:"networks,omitempty"`
+	Networks   *[]int        `json:"networks"`
 	Records    []*ZoneRecord `json:"records,omitempty"`
 
 	// Primary contains info to enable slaving of the zone by third party dns servers.
@@ -64,6 +64,10 @@ func (z Zone) MarshalJSON() ([]byte, error) {
 		aux.Networks = &z.NetworkIDs
 	}
 
+	if aux.Networks == nil {
+		aux.Networks = &[]int{}
+	}
+
 	return json.Marshal(aux)
 }
 
@@ -75,12 +79,14 @@ func (z *Zone) UnmarshalJSON(data []byte) error {
 		Alias: (*Alias)(z),
 	}
 
-	if err := json.Unmarshal(data, aux); err != nil {
+	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
 	if aux.Networks != nil {
 		z.NetworkIDs = *aux.Networks
+	} else {
+		z.NetworkIDs = []int{}
 	}
 
 	return nil

--- a/rest/model/dns/zone.go
+++ b/rest/model/dns/zone.go
@@ -35,7 +35,8 @@ type Zone struct {
 
 	// Networks contains the network ids the zone is available. Most zones
 	// will be in the NSONE Global Network(which is id 0).
-	NetworkIDs []int         `json:"networks,omitempty"`
+	NetworkIDs []int         `json:"-"`
+	Networks   *[]int        `json:"networks,omitempty"`
 	Records    []*ZoneRecord `json:"records,omitempty"`
 
 	// Primary contains info to enable slaving of the zone by third party dns servers.
@@ -49,6 +50,40 @@ type Zone struct {
 
 	// Contains the key/value tag information associated to the zone
 	Tags map[string]string `json:"tags,omitempty"` // Only relevant for DDI
+}
+
+func (z Zone) MarshalJSON() ([]byte, error) {
+	type Alias Zone
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(&z),
+	}
+
+	if z.NetworkIDs != nil {
+		aux.Networks = &z.NetworkIDs
+	}
+
+	return json.Marshal(aux)
+}
+
+func (z *Zone) UnmarshalJSON(data []byte) error {
+	type Alias Zone
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(z),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if aux.Networks != nil {
+		z.NetworkIDs = *aux.Networks
+	}
+
+	return nil
 }
 
 func (z Zone) String() string {


### PR DESCRIPTION
fix for when a zone is created with the `networks=[]`. The created zone was being attached Network 0(as it gets added to it by default when no `networks` field is used)