### PR TITLE
Fix datasource update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.15.1 (October 20th, 2025)
+
+BUG FIXES:
+
+* Fix data source update incorrectly adding the id into the body
+
 ## 2.15.0 (August 28th, 2025)
 
 FEATURES:

--- a/rest/client.go
+++ b/rest/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	clientVersion = "2.15.0"
+	clientVersion = "2.15.1"
 
 	defaultBase                   = "https://api.nsone.net"
 	defaultEndpoint               = defaultBase + "/v1/"

--- a/rest/data_source.go
+++ b/rest/data_source.go
@@ -72,6 +72,8 @@ func (s *DataSourcesService) Create(ds *data.Source) (*http.Response, error) {
 // NS1 API docs: https://ns1.com/api/#sources-post
 func (s *DataSourcesService) Update(ds *data.Source) (*http.Response, error) {
 	path := fmt.Sprintf("data/sources/%s", ds.ID)
+	// must be omitted from the body
+	ds.ID = ""
 
 	req, err := s.client.NewRequest("POST", path, &ds)
 	if err != nil {


### PR DESCRIPTION
The client is sending “id” to the API for datasource updates, which is not accepted.